### PR TITLE
Display 'Syncing' badge

### DIFF
--- a/app/javascript/packs/forkMonitorApp/components/nodes.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/nodes.jsx
@@ -118,7 +118,10 @@ class Nodes extends React.Component {
                                   <span>.{version[3]}</span>
                                 }
                               {node.unreachable_since!=null &&
-                                <Badge color="warning">Offline</Badge>
+                                <span> <Badge color="warning">Offline</Badge></span>
+                              }
+                              {node.ibd &&
+                                <span> <Badge color="info">Syncing</Badge></span>
                               }
                             </b>
                         </li>)

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -7,7 +7,7 @@ class Node < ApplicationRecord
   scope :bitcoin_by_version, -> { where(coin: "BTC").reorder(version: :desc) }
 
   def as_json(options = nil)
-    fields = [:id, :name, :version, :unreachable_since]
+    fields = [:id, :name, :version, :unreachable_since, :ibd]
     if options && options[:admin]
       fields << :id << :coin << :rpchost << :rpcuser << :rpcpassword
     end


### PR DESCRIPTION
Display a 'Syncing' badge during initial blockchain download as well as during catchup if the node has been offline for a while.
 
<img width="1128" alt="schermafbeelding 2019-02-14 om 14 26 26" src="https://user-images.githubusercontent.com/10217/52789655-bac75800-3064-11e9-82b0-02c0390d30d8.png">

(the example in this image is a node running on my own machine, not visible on the live site)