### PR TITLE
Use timestamp instead of mediantime

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -48,6 +48,7 @@ class Node < ApplicationRecord
       common_block_info = client.getblock(common_block_hash)
       common_block = Block.create_with(
         height: self.common_height,
+        mediantime: common_block_info["mediantime"],
         timestamp: common_block_info["time"],
         work: common_block_info["chainwork"]
       ).find_or_create_by(block_hash: common_block_info["hash"])
@@ -70,6 +71,7 @@ class Node < ApplicationRecord
         block = Block.create(
           block_hash: block_info["hash"],
           height: block_info["height"],
+          mediantime: block_info["mediantime"],
           timestamp: block_info["time"],
           work: block_info["chainwork"]
         )

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -6,6 +6,8 @@ class Node < ApplicationRecord
 
   scope :bitcoin_by_version, -> { where(coin: "BTC").reorder(version: :desc) }
 
+  scope :altcoin_by_version, -> { where.not(coin: "BTC").reorder(version: :desc) }
+
   def as_json(options = nil)
     fields = [:id, :name, :version, :unreachable_since, :ibd]
     if options && options[:admin]
@@ -133,11 +135,16 @@ class Node < ApplicationRecord
   end
 
   def self.poll!
-    self.all.each do |node|
+    self.bitcoin_by_version.each do |node|
       puts "Polling #{ node.coin } node #{node.id} (#{node.name})..." unless Rails.env.test?
       node.poll!
     end
     self.check_laggards!
+
+    self.altcoin_by_version.each do |node|
+      puts "Polling #{ node.coin } node #{node.id} (#{node.name})..." unless Rails.env.test?
+      node.poll!
+    end
   end
 
   def self.poll_repeat!

--- a/app/services/bitcoin_client.rb
+++ b/app/services/bitcoin_client.rb
@@ -62,6 +62,15 @@ class BitcoinClient
     end
   end
 
+  def getblockheader(hash)
+    begin
+      return request("getblockheader", hash)
+    rescue Bitcoiner::Client::JSONRPCError => e
+      puts "getblockheader(#{hash}) failed for node #{@id}: " + e.message
+      raise
+    end
+  end
+
   private
 
   def request(*args)

--- a/app/services/bitcoin_client_mock.rb
+++ b/app/services/bitcoin_client_mock.rb
@@ -17,6 +17,7 @@ class BitcoinClientMock
       560179 => "000000000000000000017b592e9ecd6ce8ab9b5a2f391e21ee2e80b022a7dafc"
     }
     @blocks = {}
+    @block_headers = {}
 
     add_mock_block(976, 1232327230, "000000000000000000000000000000000000000000000000000003d103d103d1")
     add_mock_block(560176, 1548498742, "000000000000000000000000000000000000000004dac4780fcbfd1e5710a2a5")
@@ -166,16 +167,25 @@ class BitcoinClientMock
     return @blocks[hash].tap { |b| b.delete("mediantime") if @version <= 100300 }
   end
 
+  def getblockheader(hash)  # Added in v0.12
+    raise Bitcoiner::Client::JSONRPCError if @version < 120000
+    raise Bitcoiner::Client::JSONRPCError unless @blocks[hash]
+
+    return @block_headers[hash].tap { |b| b.delete("mediantime") if @version <= 100300 }
+  end
+
   private
 
   def add_mock_block(height, mediantime, chainwork)
-    @blocks[@block_hashes[height]] = {
+    header = {
       "height" => height,
-      "mediantime" => mediantime,
       "time" => mediantime,
+      "mediantime" => mediantime,
       "chainwork" => chainwork,
       "hash" => @block_hashes[height],
       "previousblockhash" => @block_hashes[height - 1]
     }
+    @block_headers[@block_hashes[height]] = header
+    @blocks[@block_hashes[height]] = header
   end
 end

--- a/db/migrate/20190218094624_add_mediantime_to_blocks.rb
+++ b/db/migrate/20190218094624_add_mediantime_to_blocks.rb
@@ -1,0 +1,10 @@
+class AddMediantimeToBlocks < ActiveRecord::Migration[5.2]
+  def up
+    add_column :blocks, :mediantime, :integer
+    Block.update_all("mediantime=timestamp")
+  end
+
+  def down
+    remove_column :blocks, :mediantime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_26_202056) do
+ActiveRecord::Schema.define(version: 2019_02_18_094624) do
 
   create_table "blocks", force: :cascade do |t|
     t.string "block_hash"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2019_01_26_202056) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "parent_id"
+    t.integer "mediantime"
     t.index ["block_hash"], name: "index_blocks_on_block_hash", unique: true
     t.index ["parent_id"], name: "index_blocks_on_parent_id"
   end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe Node, :type => :model do
 
       it "should have correct data" do
         expect(@node.version).to equal(180500)
-        expect(@node.block.timestamp).to equal(1548515214)
+        expect(@node.block.timestamp).to equal(1548498742)
       end
     end
   end

--- a/spec/services/bitcoin_client_spec.rb
+++ b/spec/services/bitcoin_client_spec.rb
@@ -40,5 +40,12 @@ describe BitcoinClient do
         @client.getblock("hash")
       end
     end
+
+    describe "getblockheader" do
+      it "should getblockheader rpc method with hash" do
+        expect(@client).to receive(:request).with("getblockheader", "hash")
+        @client.getblockheader("hash")
+      end
+    end
   end
 end


### PR DESCRIPTION
Using `mediantime` causes nodes to appear as if they're about one hour behind. We still track this in the database, but block timestamp is nicer for the UI.