### PR TITLE
Invalid chaintip warnings

### DIFF
--- a/app/controllers/api/v1/invalid_blocks_controller.rb
+++ b/app/controllers/api/v1/invalid_blocks_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::InvalidBlocksController < ApplicationController
+
+  def index
+    @invalid_blocks = InvalidBlock.all
+    response.headers['Content-Range'] = @invalid_blocks.count
+    render json: @invalid_blocks
+  end
+
+end

--- a/app/javascript/packs/forkMonitorApp/components/chaintip.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/chaintip.jsx
@@ -10,13 +10,14 @@ import {
     Breadcrumb
 } from 'reactstrap';
 
-import Node from './node'
+import Node from './node';
 
 class Chaintip extends React.Component {
   constructor(props) {
     super(props);
 
     this.state = {
+      coin: props.coin,
       nodes: props.nodes,
       chaintip: props.chaintip,
       index: props.index,

--- a/app/javascript/packs/forkMonitorApp/components/node.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/node.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import Moment from 'react-moment';
-import NumberFormat from 'react-number-format';
 
 import {
     Badge,
@@ -9,11 +8,7 @@ import {
     Breadcrumb
 } from 'reactstrap';
 
-Number.prototype.pad = function(size) {
-  var s = String(this);
-  while (s.length < (size || 2)) {s = "0" + s;}
-  return s;
-}
+import NodeName from './nodeName';
 
 class Node extends React.Component {
   constructor(props) {
@@ -25,17 +20,10 @@ class Node extends React.Component {
   }
 
   render() {
-    const version = this.state.node.version.pad(8).split( /(?=(?:..)*$)/ ).map(Number)
     return(
       <li>
         <b>
-          {this.state.node.name}
-          <span className="node-version">
-            { " " }{version[0]}.{version[1]}.{version[2]}
-            {version[3] > 0 &&
-              <span>.{version[3]}</span>
-            }
-          </span>
+          <NodeName node={this.state.node} />
           {this.state.node.unreachable_since!=null &&
             <span> <Badge color="warning">Offline</Badge></span>
           }

--- a/app/javascript/packs/forkMonitorApp/components/nodeName.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/nodeName.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+Number.prototype.pad = function(size) {
+  var s = String(this);
+  while (s.length < (size || 2)) {s = "0" + s;}
+  return s;
+}
+
+class NodeName extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      node: props.node
+    };
+  }
+
+  render() {
+    const version = this.state.node.version.pad(8).split( /(?=(?:..)*$)/ ).map(Number)
+    return(
+      <span>
+        {this.state.node.name}
+        <span className="node-version">
+          { " " }{version[0]}.{version[1]}.{version[2]}
+          {version[3] > 0 &&
+            <span>.{version[3]}</span>
+          }
+        </span>
+      </span>
+    )
+  }
+}
+export default NodeName

--- a/app/javascript/packs/forkMonitorApp/components/nodes.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/nodes.jsx
@@ -8,7 +8,8 @@ import {
     UncontrolledAlert
 } from 'reactstrap';
 
-import Chaintip from './chaintip'
+import Chaintip from './chaintip';
+import NodeName from './nodeName';
 
 axios.defaults.headers.post['Content-Type'] = 'application/json'
 
@@ -19,14 +20,20 @@ class Nodes extends React.Component {
     this.state = {
       coin: props.match.params.coin,
       nodes: [],
-      chaintips: []
+      chaintips: [],
+      invalid_blocks: []
     };
 
     this.getNodes = this.getNodes.bind(this);
+    this.getInvalidBlocks = this.getInvalidBlocks.bind(this);
   }
 
   componentDidMount() {
     this.getNodes(this.state.coin);
+
+    if (this.state.coin == "btc") {
+      this.getInvalidBlocks();
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -44,24 +51,36 @@ class Nodes extends React.Component {
   }
 
   getNodes(coin) {
-   axios.get('/api/v1/nodes/coin/' + coin).then(function (response) {
-     return response.data;
-   }).then(function (nodes) {
-     var unique = (arrArg) => arrArg.filter((elem, pos, arr) => arr.findIndex(x => x.best.hash === elem.best.hash) == pos)
+    axios.get('/api/v1/nodes/coin/' + coin).then(function (response) {
+      return response.data;
+    }).then(function (nodes) {
+      var unique = (arrArg) => arrArg.filter((elem, pos, arr) => arr.findIndex(x => x.best.hash === elem.best.hash) == pos)
 
-     var chaintips_and_common = unique(nodes.map(node => ({best: node.best_block, common: node.common_block})));
+      var chaintips_and_common = unique(nodes.map(node => ({best: node.best_block, common: node.common_block})));
 
-     this.setState({
-       coin: coin,
-       nodes: nodes,
-       chaintips: chaintips_and_common.map(x => x.best),
-       chaintips_common_block: chaintips_and_common.map(x => x.common)
-     });
+      this.setState({
+        coin: coin,
+        nodes: nodes,
+        chaintips: chaintips_and_common.map(x => x.best),
+        chaintips_common_block: chaintips_and_common.map(x => x.common)
+      });
 
-   }.bind(this)).catch(function (error) {
-     console.error(error);
-   });
- }
+      }.bind(this)).catch(function (error) {
+        console.error(error);
+      });
+   }
+
+   getInvalidBlocks() {
+     axios.get('/api/v1/invalid_blocks').then(function (response) {
+       return response.data;
+     }).then(function (invalid_blocks) {
+       this.setState({
+         invalid_blocks: invalid_blocks
+       });
+    }.bind(this)).catch(function (error) {
+      console.error(error);
+    });
+  }
 
   render() {
       return(
@@ -72,15 +91,31 @@ class Nodes extends React.Component {
               The last common block between ABC and SV was mined. Height: 556766, Log2(PoW): 87.723, Hash: 00000000000000000102d94fde9bd0807a2cc7582fe85dd6349b73ce4e8d9322 at 17:52 UTC on 15th November 2018
             </UncontrolledAlert>
           }
+          { (this.state.coin === "btc" && this.state && this.state.invalid_blocks || []).map(function (invalid_block) {
+            return (
+                <UncontrolledAlert color="danger" key={invalid_block.id}>
+                  <NodeName node={invalid_block.node} /> considers
+                  block { invalid_block.block.hash } at height { invalid_block.block.height } invalid.
+                  { invalid_block.block.first_seen_by &&
+                    <span>
+                      { } This block was first seen and accepted as valid by <NodeName node={invalid_block.block.first_seen_by} />.
+                    </span>
+                  }
+
+                </UncontrolledAlert>
+            )
+          }.bind(this))}
           <Container>
               {(this.state && this.state.chaintips || []).map(function (chaintip, index) {
                 return (<Chaintip
                   key={ chaintip.hash }
+                  coin={ this.state.coin }
                   chaintip={ chaintip }
                   nodes={ this.state.nodes }
                   index={ index }
                   last={ index != this.state.chaintips.length - 1 }
                   common_block={ this.state.chaintips_common_block[index] }
+                  invalid_blocks={ this.state.invalid_blocks }
                 />)
               }.bind(this))}
           </Container>

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -8,4 +8,14 @@ class UserMailer < ApplicationMailer
       subject: "[ForkMonitor] #{ @lag.node_a.name } #{ @lag.node_a.version } is #{ @lag.node_b.block.height - @lag.node_a.block.height } blocks behind #{ @lag.node_b.version }"
     )
   end
+
+  def invalid_block_email
+    @user = params[:user]
+    @invalid_block = params[:invalid_block]
+
+    mail(
+      to: @user.email,
+      subject: "[ForkMonitor] #{ @invalid_block.node.name } #{ @invalid_block.node.version } considers block #{ @invalid_block.block.height } (#{ @invalid_block.block.block_hash }) invalid"
+    )
+  end
 end

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -5,7 +5,7 @@ class Block < ApplicationRecord
   belongs_to :first_seen_by, class_name: 'Node', foreign_key: 'first_seen_by_id', optional: true
 
   def as_json(options = nil)
-    super({ only: [:height, :timestamp] }.merge(options || {})).merge({hash: block_hash, work: log2_pow})
+    super({ only: [:height, :timestamp] }.merge(options || {})).merge({hash: block_hash, work: log2_pow, first_seen_by: first_seen_by})
   end
 
   def log2_pow

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -1,6 +1,7 @@
 class Block < ApplicationRecord
   has_many :children, class_name: 'Block', foreign_key: 'parent_id'
   belongs_to :parent, class_name: 'Block', foreign_key: 'parent_id', optional: true
+  has_many :invalid_blocks
 
   def as_json(options = nil)
     super({ only: [:height, :timestamp] }.merge(options || {})).merge({hash: block_hash, work: log2_pow})

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -2,6 +2,7 @@ class Block < ApplicationRecord
   has_many :children, class_name: 'Block', foreign_key: 'parent_id'
   belongs_to :parent, class_name: 'Block', foreign_key: 'parent_id', optional: true
   has_many :invalid_blocks
+  belongs_to :first_seen_by, class_name: 'Node', foreign_key: 'first_seen_by_id', optional: true
 
   def as_json(options = nil)
     super({ only: [:height, :timestamp] }.merge(options || {})).merge({hash: block_hash, work: log2_pow})

--- a/app/models/invalid_block.rb
+++ b/app/models/invalid_block.rb
@@ -1,4 +1,8 @@
 class InvalidBlock < ApplicationRecord
   belongs_to :block
   belongs_to :node
+
+  def as_json(options = nil)
+    super({ only: [:id] }).merge({block: block, node: node})
+  end
 end

--- a/app/models/invalid_block.rb
+++ b/app/models/invalid_block.rb
@@ -1,0 +1,4 @@
+class InvalidBlock < ApplicationRecord
+  belongs_to :block
+  belongs_to :node
+end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -53,7 +53,8 @@ class Node < ApplicationRecord
         height: self.common_height,
         mediantime: common_block_info["mediantime"],
         timestamp: common_block_info["time"],
-        work: common_block_info["chainwork"]
+        work: common_block_info["chainwork"],
+        first_seen_by: self
       ).find_or_create_by(block_hash: common_block_info["hash"])
       self.update common_block: common_block
     end
@@ -226,7 +227,8 @@ class Node < ApplicationRecord
           height: block_info["height"],
           mediantime: block_info["mediantime"],
           timestamp: block_info["time"],
-          work: block_info["chainwork"]
+          work: block_info["chainwork"],
+          first_seen_by: self
         )
       end
 
@@ -268,7 +270,8 @@ class Node < ApplicationRecord
         height: block_info["height"],
         mediantime: block_info["mediantime"],
         timestamp: block_info["time"],
-        work: block_info["chainwork"]
+        work: block_info["chainwork"],
+        first_seen_by: self
       )
       block.update parent: parent
 

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -75,7 +75,7 @@ class Node < ApplicationRecord
   # any of our other nodes saw this block, found it to have enough proof of work
   # and considered it valid. This can normally happen under two circumstances:
   # 1. the node is unaware of a soft-fork and initially accepts a block that newer
-  #    nodes reject. We detect this if we poll the node before the block is reorgd out.
+  #    nodes reject
   # 2. the node has a consensus bug
   def check_chaintips!
     # Return nil if node is unreachble:
@@ -84,6 +84,8 @@ class Node < ApplicationRecord
     chaintips = client.getchaintips
     chaintips.each do |chaintip|
       case chaintip["status"]
+      when "valid-fork"
+        find_or_create_block_and_ancestors!(chaintip["hash"]) unless chaintip["height"] < self.block.height - 1000
       when "invalid"
         block = Block.find_by(block_hash: chaintip["hash"])
         return block if block

--- a/app/services/bitcoin_client.rb
+++ b/app/services/bitcoin_client.rb
@@ -71,6 +71,16 @@ class BitcoinClient
     end
   end
 
+  def getchaintips
+    begin
+      return request("getchaintips")
+    rescue Bitcoiner::Client::JSONRPCError => e
+      puts "getchaintips failed for node #{@id}: " + e.message
+      raise
+    end
+  end
+
+
   private
 
   def request(*args)

--- a/app/services/bitcoin_client_mock.rb
+++ b/app/services/bitcoin_client_mock.rb
@@ -20,11 +20,11 @@ class BitcoinClientMock
     @blocks = {}
     @block_headers = {}
 
-    add_mock_block(976, 1232327230, "000000000000000000000000000000000000000000000000000003d103d103d1")
-    add_mock_block(560176, 1548498742, "000000000000000000000000000000000000000004dac4780fcbfd1e5710a2a5")
-    add_mock_block(560177, 1548500251, "000000000000000000000000000000000000000004dac9d20e304bee0e69b31a")
-    add_mock_block(560178, 1548502864, "000000000000000000000000000000000000000004dacf2c0c949abdc5c2c38f")
-    add_mock_block(560179, 1548503410, "000000000000000000000000000000000000000004dad4860af8e98d7d1bd404")
+    mock_add_block(976, 1232327230, "000000000000000000000000000000000000000000000000000003d103d103d1")
+    mock_add_block(560176, 1548498742, "000000000000000000000000000000000000000004dac4780fcbfd1e5710a2a5")
+    mock_add_block(560177, 1548500251, "000000000000000000000000000000000000000004dac9d20e304bee0e69b31a")
+    mock_add_block(560178, 1548502864, "000000000000000000000000000000000000000004dacf2c0c949abdc5c2c38f")
+    mock_add_block(560179, 1548503410, "000000000000000000000000000000000000000004dad4860af8e98d7d1bd404")
 
   end
 
@@ -200,8 +200,8 @@ class BitcoinClientMock
   end
 
   def getblockheader(hash)  # Added in v0.12
-    raise Bitcoiner::Client::JSONRPCError if @version < 120000
-    raise Bitcoiner::Client::JSONRPCError unless @blocks[hash]
+    raise Bitcoiner::Client::JSONRPCError, hash if @version < 120000
+    raise Bitcoiner::Client::JSONRPCError, hash unless @blocks[hash]
 
     return @block_headers[hash].tap { |b| b.delete("mediantime") if @version <= 100300 }
   end
@@ -210,18 +210,18 @@ class BitcoinClientMock
     @chaintips
   end
 
-  private
-
-  def add_mock_block(height, mediantime, chainwork)
+  def mock_add_block(height, mediantime, chainwork, block_hash = nil, previousblockhash = nil)
+    block_hash ||= @block_hashes[height]
+    previousblockhash ||= @block_hashes[height - 1]
     header = {
       "height" => height,
       "time" => mediantime,
       "mediantime" => mediantime,
       "chainwork" => chainwork,
-      "hash" => @block_hashes[height],
-      "previousblockhash" => @block_hashes[height - 1]
+      "hash" => block_hash,
+      "previousblockhash" => previousblockhash
     }
-    @block_headers[@block_hashes[height]] = header
-    @blocks[@block_hashes[height]] = header
+    @block_headers[block_hash] = header
+    @blocks[block_hash] = header
   end
 end

--- a/app/services/bitcoin_client_mock.rb
+++ b/app/services/bitcoin_client_mock.rb
@@ -6,6 +6,7 @@ class BitcoinClientMock
     @peer_count = 100
     @version = 170100
     @coin = "BTC"
+    @chaintips = []
 
     @block_hashes = {
       975 => "00000000d67ac3dab052ac69301316b73678703e719ce3757e31e5b92444e64c",
@@ -55,6 +56,10 @@ class BitcoinClientMock
     @peer_count = peer_count
   end
 
+  def mock_chaintips(tips)
+    @chaintips = tips
+  end
+
   def getnetworkinfo
     raise Bitcoiner::Client::JSONRPCError if !@reachable
     if @coin == "BTC"
@@ -81,6 +86,17 @@ class BitcoinClientMock
           ],
           "relayfee" => 0.00001000,
           "localaddresses" => [],
+          "warnings" => ""
+        },
+        160300 => {
+          "version" => 160300,
+          "subversion" => "/Satoshi:0.16.3/",
+          "protocolversion" => 70015,
+          "localservices" => "0000000000000409",
+          "localrelay" => true,
+          "timeoffset" => -1,
+          "networkactive" => true,
+          "connections" => @peer_count,
           "warnings" => ""
         },
         170100 => {
@@ -113,6 +129,22 @@ class BitcoinClientMock
   def getblockchaininfo
     {
       170100 => {
+        "chain" => "main",
+        "blocks" => @height,
+        "headers" => @height,
+        "bestblockhash" => @block_hashes[@height],
+        # "difficulty" => 5883988430955.408,
+        "mediantime" => 1548515214,
+        "verificationprogress" => @ibd ? 1.753483709675226e-06 : 1.0,
+        "initialblockdownload" => @ibd,
+        "chainwork" => @blocks[@block_hashes[@height]]["chainwork"],
+        "size_on_disk" => 229120703086 + (@height - 560179) * 2000000,
+        "pruned" => false,
+        "softforks" => [],
+        "bip9_softforks" => {},
+        "warnings" => ""
+      },
+      160300 => {
         "chain" => "main",
         "blocks" => @height,
         "headers" => @height,
@@ -172,6 +204,10 @@ class BitcoinClientMock
     raise Bitcoiner::Client::JSONRPCError unless @blocks[hash]
 
     return @block_headers[hash].tap { |b| b.delete("mediantime") if @version <= 100300 }
+  end
+
+  def getchaintips
+    @chaintips
   end
 
   private

--- a/app/views/user_mailer/invalid_block_email.html.erb
+++ b/app/views/user_mailer/invalid_block_email.html.erb
@@ -1,3 +1,8 @@
+<% if @invalid_block.block.first_seen_by.present? %>
+<p>
+  This block was first seen and accepted as valid by <%= @invalid_block.block.first_seen_by.name %> <%= @invalid_block.block.first_seen_by.version %>.
+</p>
+<% end %>
 
 <p>
   For more information, see: <%= nodes_btc_url %>

--- a/app/views/user_mailer/invalid_block_email.html.erb
+++ b/app/views/user_mailer/invalid_block_email.html.erb
@@ -1,0 +1,4 @@
+
+<p>
+  For more information, see: <%= nodes_btc_url %>
+</p>

--- a/app/views/user_mailer/invalid_block_email.text.erb
+++ b/app/views/user_mailer/invalid_block_email.text.erb
@@ -1,1 +1,5 @@
+<% if @invalid_block.block.first_seen_by.present? %>
+  This block was first seen and accepted as valid by <%= @invalid_block.block.first_seen_by.name %> <%= @invalid_block.block.first_seen_by.version %>.
+<% end %>
+
 For more information, see: <%= nodes_btc_url %>

--- a/app/views/user_mailer/invalid_block_email.text.erb
+++ b/app/views/user_mailer/invalid_block_email.text.erb
@@ -1,0 +1,1 @@
+For more information, see: <%= nodes_btc_url %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       match '/nodes/coin/:coin', :to => 'nodes#index_coin', :as => "nodes_for_coin", :via => :get
       resources :nodes, only: [:index, :show, :update, :destroy, :create]
+      resources :invalid_blocks, only: [:index]
     end
   end
 

--- a/db/migrate/20190218163224_create_invalid_blocks.rb
+++ b/db/migrate/20190218163224_create_invalid_blocks.rb
@@ -1,0 +1,11 @@
+class CreateInvalidBlocks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :invalid_blocks do |t|
+      t.references :block, foreign_key: true
+      t.references :node, foreign_key: true
+      t.datetime :notified_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190218165700_add_first_seen_by_to_blocks.rb
+++ b/db/migrate/20190218165700_add_first_seen_by_to_blocks.rb
@@ -1,0 +1,5 @@
+class AddFirstSeenByToBlocks < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :blocks, :first_seen_by, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_18_094624) do
+ActiveRecord::Schema.define(version: 2019_02_18_163224) do
 
   create_table "blocks", force: :cascade do |t|
     t.string "block_hash"
@@ -23,6 +23,16 @@ ActiveRecord::Schema.define(version: 2019_02_18_094624) do
     t.integer "mediantime"
     t.index ["block_hash"], name: "index_blocks_on_block_hash", unique: true
     t.index ["parent_id"], name: "index_blocks_on_parent_id"
+  end
+
+  create_table "invalid_blocks", force: :cascade do |t|
+    t.integer "block_id"
+    t.integer "node_id"
+    t.datetime "notified_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["block_id"], name: "index_invalid_blocks_on_block_id"
+    t.index ["node_id"], name: "index_invalid_blocks_on_node_id"
   end
 
   create_table "jwt_blacklist", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_18_163224) do
+ActiveRecord::Schema.define(version: 2019_02_18_165700) do
 
   create_table "blocks", force: :cascade do |t|
     t.string "block_hash"
@@ -21,7 +21,9 @@ ActiveRecord::Schema.define(version: 2019_02_18_163224) do
     t.datetime "updated_at", null: false
     t.integer "parent_id"
     t.integer "mediantime"
+    t.integer "first_seen_by_id"
     t.index ["block_hash"], name: "index_blocks_on_block_hash", unique: true
+    t.index ["first_seen_by_id"], name: "index_blocks_on_first_seen_by_id"
     t.index ["parent_id"], name: "index_blocks_on_parent_id"
   end
 

--- a/spec/factories/invalid_blocks.rb
+++ b/spec/factories/invalid_blocks.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+   factory :invalid_block do
+     association :node, factory: :node_with_block, version: 170100
+     association :block, factory: :block
+   end
+ end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -19,7 +19,12 @@ RSpec.describe UserMailer, type: :mailer do
   describe "invalid block notify" do
     let(:user) { create(:user) }
     let(:invalid_block) { create(:invalid_block) }
+    let(:node2) { create(:node_with_block, version: 160300) }
     let(:mail) { UserMailer.with(user: user, invalid_block: invalid_block).invalid_block_email }
+
+    before do
+      invalid_block.block.update first_seen_by: node2
+    end
 
     it "renders the headers" do
       expect(mail.subject).to eq("[ForkMonitor] Bitcoin Core 170100 considers block #{ invalid_block.block.height } (#{ invalid_block.block.block_hash }) invalid")
@@ -29,5 +34,10 @@ RSpec.describe UserMailer, type: :mailer do
     it "renders the body" do
       expect(mail.body.encoded).to include("https://forkmonitor.info/nodes/btc")
     end
+
+    it "mentions which node first saw the block" do
+      expect(mail.body.encoded).to include("Bitcoin Core 160300")
+    end
+
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,18 +1,33 @@
 require "rails_helper"
 
 RSpec.describe UserMailer, type: :mailer do
-  describe "notify" do
-   let(:user) { create(:user) }
-   let(:lag) { create(:lag) }
-   let(:mail) { UserMailer.with(user: user, lag: lag).lag_email }
+  describe "lag notify" do
+    let(:user) { create(:user) }
+    let(:lag) { create(:lag) }
+    let(:mail) { UserMailer.with(user: user, lag: lag).lag_email }
 
-   it "renders the headers" do
-     expect(mail.subject).to eq("[ForkMonitor] Bitcoin Core 100300 is 1 blocks behind 170100")
-     expect(mail.to).to eq([user.email])
-   end
+    it "renders the headers" do
+      expect(mail.subject).to eq("[ForkMonitor] Bitcoin Core 100300 is 1 blocks behind 170100")
+      expect(mail.to).to eq([user.email])
+    end
 
-   it "renders the body" do
-     expect(mail.body.encoded).to include("https://forkmonitor.info/nodes/btc")
-   end
- end
+    it "renders the body" do
+      expect(mail.body.encoded).to include("https://forkmonitor.info/nodes/btc")
+    end
+  end
+
+  describe "invalid block notify" do
+    let(:user) { create(:user) }
+    let(:invalid_block) { create(:invalid_block) }
+    let(:mail) { UserMailer.with(user: user, invalid_block: invalid_block).invalid_block_email }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("[ForkMonitor] Bitcoin Core 170100 considers block #{ invalid_block.block.height } (#{ invalid_block.block.block_hash }) invalid")
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to include("https://forkmonitor.info/nodes/btc")
+    end
+  end
 end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe Node, :type => :model do
       it "should store intermediate blocks" do
         @node.client.mock_set_height(560179)
         @node.poll!
+        @node.reload
         expect(@node.block.height).to equal(560179)
         expect(@node.block.parent).not_to be_nil
         expect(@node.block.parent.height).to equal(560178)
@@ -84,6 +85,7 @@ RSpec.describe Node, :type => :model do
         @node.update coin: "BCH"
         @node.client.mock_set_height(560178)
         @node.poll!
+        @node.reload
         expect(@node.block.height).to equal(560178)
         expect(@node.block.parent.parent).to be_nil
       end
@@ -92,6 +94,7 @@ RSpec.describe Node, :type => :model do
         @node.client.mock_ibd(true)
         @node.client.mock_set_height(976)
         @node.poll!
+        @node.reload
         expect(@node.block.height).to equal(976)
         expect(@node.block.parent).to be_nil
       end
@@ -105,12 +108,14 @@ RSpec.describe Node, :type => :model do
         @node.client.mock_ibd(false)
         @node.client.mock_set_height(560177)
         @node.poll!
+        @node.reload
         expect(@node.block.height).to equal(560177)
         expect(@node.block.parent).to be_nil
 
         # Two blocks later, now it should fetch intermediate blocks:
         @node.client.mock_set_height(560179)
         @node.poll!
+        @node.reload
         expect(@node.block.height).to equal(560179)
         expect(@node.block.parent.height).to equal(560178)
       end
@@ -153,6 +158,7 @@ RSpec.describe Node, :type => :model do
       it "should store intermediate blocks" do
         @node.client.mock_set_height(560179)
         @node.poll!
+        @node.reload
         expect(@node.block.height).to equal(560179)
         expect(@node.block.parent).not_to be_nil
         expect(@node.block.parent.height).to equal(560178)
@@ -180,6 +186,7 @@ RSpec.describe Node, :type => :model do
       it "should store intermediate blocks" do
         @node.client.mock_set_height(560179)
         @node.poll!
+        @node.reload
         expect(@node.block.height).to equal(560179)
         expect(@node.block.parent).not_to be_nil
         expect(@node.block.parent.height).to equal(560178)
@@ -207,11 +214,15 @@ RSpec.describe Node, :type => :model do
     before do
       @A = build(:node)
       @A.client.mock_version(170100)
+      @A.client.mock_set_height(560176)
+      @A.poll!
       @A.client.mock_set_height(560178)
       @A.poll!
 
       @B = build(:node)
       @B.client.mock_version(160300)
+      @B.client.mock_set_height(560176)
+      @B.poll!
       @B.client.mock_set_height(560178)
       @B.poll!
     end
@@ -222,8 +233,8 @@ RSpec.describe Node, :type => :model do
           {
             "height" => 560178,
             "hash" => "00000000000000000016816bd3f4da655a4d1fd326a3313fa086c2e337e854f9",
-            "branchlen": 0,
-            "status": "active"
+            "branchlen" => 0,
+            "status" => "active"
           }
         ])
       end
@@ -238,13 +249,13 @@ RSpec.describe Node, :type => :model do
           {
             "height" => 560178,
             "hash" => "00000000000000000016816bd3f4da655a4d1fd326a3313fa086c2e337e854f9",
-            "branchlen": 0,
-            "status": "active"
+            "branchlen" => 0,
+            "status" => "active"
           }, {
             "height" => 560178,
             "hash" => "0000000000000000000000000000000000000000000000000000000000560178",
-            "branchlen": 0,
-            "status": "valid-fork"
+            "branchlen" => 2,
+            "status" => "valid-fork"
           }
         ])
       end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Node, :type => :model do
         @node.poll!
         expect(@node.block).not_to be_nil
         expect(@node.block.height).to equal(560176)
+        expect(@node.block.first_seen_by).to eq(@node)
       end
 
       it "should get IBD status, if true" do
@@ -77,6 +78,7 @@ RSpec.describe Node, :type => :model do
         expect(@node.block.height).to equal(560179)
         expect(@node.block.parent).not_to be_nil
         expect(@node.block.parent.height).to equal(560178)
+        expect(@node.block.parent.first_seen_by).to eq(@node)
         expect(@node.block.parent.parent).not_to be_nil
         expect(@node.block.parent.parent.height).to equal(560177)
       end

--- a/test/javascript/node.test.js
+++ b/test/javascript/node.test.js
@@ -25,11 +25,6 @@ describe('Node', () => {
       node={ node }
     />)
   });
-
-  test('should display version', () => {
-    expect(wrapper.find('.node-version')).toHaveLength(1);
-    expect(wrapper.find('.node-version').text()).toContain("0.17.1");
-  });
 });
 
 describe('Sync', () => {

--- a/test/javascript/nodeName.test.js
+++ b/test/javascript/nodeName.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { shallow, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+configure({ adapter: new Adapter() });
+
+import NodeName from 'forkMonitorApp/components/nodeName';
+
+const chaintip = {
+  hash: "abcd",
+  height: 500000,
+  timestamp: 1,
+  work: 86.000001
+}
+
+let wrapper;
+
+describe('NodeName', () => {
+  const node = {id: 1, name: "Bitcoin Core", version: 170100, best_block: chaintip, unreachable_since: null, ibd: false};
+
+  beforeAll(() => {
+    wrapper = shallow(<NodeName
+      key={ 0 }
+      node={ node }
+    />)
+  });
+
+  test('should display version', () => {
+    expect(wrapper.find('.node-version')).toHaveLength(1);
+    expect(wrapper.find('.node-version').text()).toContain("0.17.1");
+  });
+});


### PR DESCRIPTION
`getchaintips` returns all known chaintips for a node, which can be:
  * `active`: the current chaintip, added to our database with `poll!`
  * `valid-fork`: valid chain, but not the most proof-of-work
  * `valid-headers`: potentially valid chain, but not fully checked due to insufficient proof-of-work
  * `headers-only`: same as valid-header, but even less checking done
  * `invalid`: checked and found invalid. Other nodes usually won't accept this block, and so it won't show up in our blocks database, because:
     1) it hasn't seen it all; or
     2) it did see it and also considers it invalid; or
     3) it didn't bother to check because it doesn't have enough proof-of-work

So if any `invalid` block, according to any node, does show up in our database, we know there is a problem.

 We check all invalid `chaintips` against the database, to see if at any point in time
 any of our other nodes saw this block, found it to have enough proof of work
 and considered it valid. This can normally happen under two circumstances:
  
1. the node is unaware of a soft-fork and initially accepts a block that newer nodes reject (this should never happen unless miners ignore IsStandard rules)
2. the node has a consensus bug

Once this is detected we send out an email. We also display a message on the site:

<img width="973" alt="schermafbeelding 2019-02-18 om 19 57 03" src="https://user-images.githubusercontent.com/10217/52971481-ea08fc80-33b7-11e9-9f69-a6c350384307.png">