### PR TITLE
Version bit email alerts

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -18,4 +18,17 @@ class UserMailer < ApplicationMailer
       subject: "[ForkMonitor] #{ @invalid_block.node.name } #{ @invalid_block.node.version } considers block #{ @invalid_block.block.height } (#{ @invalid_block.block.block_hash }) invalid"
     )
   end
+
+  def version_bits_email
+    @user = params[:user]
+    @bit = params[:bit]
+    @tally = params[:tally]
+    @window = params[:window]
+    @block = params[:block]
+
+    mail(
+      to: @user.email,
+      subject: "[ForkMonitor] version bit #{ @bit } was set #{ @tally } times between blocks #{ @block.height - @window + 1 } and #{ @block.height }"
+    )
+  end
 end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -60,7 +60,7 @@ class Node < ApplicationRecord
       self.update common_block: common_block
     end
 
-    block = self.ibd ? nil : find_or_create_block_and_ancestors!(blockchaininfo["bestblockhash"]) unless self.ibd
+    block = self.ibd ? nil : find_or_create_block_and_ancestors!(blockchaininfo["bestblockhash"])
     self.update block: block, unreachable_since: nil
   end
 
@@ -286,7 +286,7 @@ class Node < ApplicationRecord
       # Prevent new instances from going too far back due to Bitcoin Cash fork blocks:
       oldest_block = [Block.minimum(:height), 560000].max
 
-      find_block_ancestors!(block, oldest_block ? oldest_block : block.height)
+      find_block_ancestors!(block, oldest_block)
     rescue
       raise if Rails.env.test?
       retry

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -54,6 +54,7 @@ class Node < ApplicationRecord
         mediantime: common_block_info["mediantime"],
         timestamp: common_block_info["time"],
         work: common_block_info["chainwork"],
+        version: block_info["version"],
         first_seen_by: self
       ).find_or_create_by(block_hash: common_block_info["hash"])
       self.update common_block: common_block
@@ -187,6 +188,7 @@ class Node < ApplicationRecord
           mediantime: block_info["mediantime"],
           timestamp: block_info["time"],
           work: block_info["chainwork"],
+          version: block_info["version"],
           first_seen_by: self
         )
         block.update parent: parent
@@ -276,6 +278,7 @@ class Node < ApplicationRecord
           mediantime: block_info["mediantime"],
           timestamp: block_info["time"],
           work: block_info["chainwork"],
+          version: block_info["version"],
           first_seen_by: self
         )
       end

--- a/app/models/version_bit.rb
+++ b/app/models/version_bit.rb
@@ -1,0 +1,4 @@
+class VersionBit < ApplicationRecord
+  belongs_to :activate, foreign_key: "activate_block_id", class_name: "Block"
+  belongs_to :deactivate, foreign_key: "deactivate_block_id", class_name: "Block", required: false
+end

--- a/app/services/bitcoin_client_mock.rb
+++ b/app/services/bitcoin_client_mock.rb
@@ -15,17 +15,22 @@ class BitcoinClientMock
       560176 => "0000000000000000000b1e380c92ea32288b0106ef3ed820db3b374194b15aab",
       560177 => "00000000000000000009eeed38d42da6428b0dcf596093a9d313bdd3d87c0eef",
       560178 => "00000000000000000016816bd3f4da655a4d1fd326a3313fa086c2e337e854f9",
-      560179 => "000000000000000000017b592e9ecd6ce8ab9b5a2f391e21ee2e80b022a7dafc"
+      560179 => "000000000000000000017b592e9ecd6ce8ab9b5a2f391e21ee2e80b022a7dafc",
+      560180 => "0000000000000000002d802cf5fdbbfa94926be7f03b40be75eb6c3c13cbc8e4",
+      560181 => "0000000000000000002641ea2457674fea1b2fc5fcfe6fde416dca2a0e13aec2",
+      560182 => "0000000000000000002593e1504eb5c5813cac4657d78a04d81ff4e2250d3377"
     }
     @blocks = {}
     @block_headers = {}
 
-    mock_add_block(976, 1232327230, "000000000000000000000000000000000000000000000000000003d103d103d1")
-    mock_add_block(560176, 1548498742, "000000000000000000000000000000000000000004dac4780fcbfd1e5710a2a5")
-    mock_add_block(560177, 1548500251, "000000000000000000000000000000000000000004dac9d20e304bee0e69b31a")
-    mock_add_block(560178, 1548502864, "000000000000000000000000000000000000000004dacf2c0c949abdc5c2c38f")
-    mock_add_block(560179, 1548503410, "000000000000000000000000000000000000000004dad4860af8e98d7d1bd404")
-
+    mock_add_block(976, 1232327230, "000000000000000000000000000000000000000000000000000003d103d103d1", nil, nil, [])
+    mock_add_block(560176, 1548498742, "000000000000000000000000000000000000000004dac4780fcbfd1e5710a2a5", nil, nil, [])
+    mock_add_block(560177, 1548500251, "000000000000000000000000000000000000000004dac9d20e304bee0e69b31a", nil, nil, [1])
+    mock_add_block(560178, 1548502864, "000000000000000000000000000000000000000004dacf2c0c949abdc5c2c38f", nil, nil, [1, 2])
+    mock_add_block(560179, 1548503410, "000000000000000000000000000000000000000004dad4860af8e98d7d1bd404", nil, nil, [])
+    mock_add_block(560180, 1548498447, "000000000000000000000000000000000000000004dad9e0095d385d3474e479", nil, nil, [])
+    mock_add_block(560181, 1548498742, "000000000000000000000000000000000000000004dadf3a07c1872cebcdf4ee", nil, nil, [])
+    mock_add_block(560182, 1548500251, "000000000000000000000000000000000000000004dae4940625d5fca3270563", nil, nil, [])
   end
 
   def mock_coin(coin)
@@ -210,16 +215,23 @@ class BitcoinClientMock
     @chaintips
   end
 
-  def mock_add_block(height, mediantime, chainwork, block_hash = nil, previousblockhash = nil)
+  def mock_add_block(height, mediantime, chainwork, block_hash=nil, previousblockhash=nil, version_bits=nil)
     block_hash ||= @block_hashes[height]
     previousblockhash ||= @block_hashes[height - 1]
+    version_bits ||= []
+    version = 0
+    version_bits.each do |bit|
+      version = version + (1 << (bit - 1))
+    end
+
     header = {
       "height" => height,
       "time" => mediantime,
       "mediantime" => mediantime,
       "chainwork" => chainwork,
       "hash" => block_hash,
-      "previousblockhash" => previousblockhash
+      "previousblockhash" => previousblockhash,
+      "version" => version
     }
     @block_headers[block_hash] = header
     @blocks[block_hash] = header

--- a/app/views/user_mailer/version_bits_email.html.erb
+++ b/app/views/user_mailer/version_bits_email.html.erb
@@ -1,0 +1,5 @@
+This could either indicate signalling for an unknown new softfork or miner grinding the block version field.
+
+<p>
+  For more information, see: <%= nodes_btc_url %>
+</p>

--- a/app/views/user_mailer/version_bits_email.text.erb
+++ b/app/views/user_mailer/version_bits_email.text.erb
@@ -1,0 +1,3 @@
+This could either indicate signalling for an unknown new softfork or miner grinding the block version field.
+
+For more information, see: <%= nodes_btc_url %>

--- a/db/migrate/20190225153608_add_version_bits_to_blocks.rb
+++ b/db/migrate/20190225153608_add_version_bits_to_blocks.rb
@@ -1,0 +1,18 @@
+class AddVersionBitsToBlocks < ActiveRecord::Migration[5.2]
+  def up
+    add_column :blocks, :version, :int
+    node = Node.where(coin: "BTC").reorder(version: :desc).first
+    if node.present?
+      block = node.block
+      while true
+        block_header = node.client.getblockheader(block.block_hash)
+        block.update version: block_header["version"]
+        break unless block = block.parent
+      end
+    end
+  end
+
+  def down
+    add_column :blocks, :version_bits
+  end
+end

--- a/db/migrate/20190304135206_create_version_bits.rb
+++ b/db/migrate/20190304135206_create_version_bits.rb
@@ -1,0 +1,12 @@
+class CreateVersionBits < ActiveRecord::Migration[5.2]
+  def change
+    create_table :version_bits do |t|
+      t.integer :bit
+      t.references :activate_block, foreign_key: { to_table: :blocks }
+      t.references :deactivate_block, foreign_key: { to_table: :blocks }
+      t.datetime :notified_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_18_163224) do
+ActiveRecord::Schema.define(version: 2019_02_25_153608) do
 
   create_table "blocks", force: :cascade do |t|
     t.string "block_hash"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2019_02_18_163224) do
     t.integer "parent_id"
     t.integer "mediantime"
     t.integer "first_seen_by_id"
+    t.integer "version"
     t.index ["block_hash"], name: "index_blocks_on_block_hash", unique: true
     t.index ["first_seen_by_id"], name: "index_blocks_on_first_seen_by_id"
     t.index ["parent_id"], name: "index_blocks_on_parent_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_25_153608) do
+ActiveRecord::Schema.define(version: 2019_03_04_135206) do
 
   create_table "blocks", force: :cascade do |t|
     t.string "block_hash"
@@ -85,6 +85,17 @@ ActiveRecord::Schema.define(version: 2019_02_25_153608) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "version_bits", force: :cascade do |t|
+    t.integer "bit"
+    t.integer "activate_block_id"
+    t.integer "deactivate_block_id"
+    t.datetime "notified_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["activate_block_id"], name: "index_version_bits_on_activate_block_id"
+    t.index ["deactivate_block_id"], name: "index_version_bits_on_deactivate_block_id"
   end
 
 end

--- a/lib/tasks/blocks.rake
+++ b/lib/tasks/blocks.rake
@@ -3,4 +3,13 @@ namespace 'blocks' do :env
   task :fetch_ancestors, [:height] => :environment do |action, args|
     Node.fetch_ancestors!(args.height.to_i)
   end
+
+  desc "List version bits"
+  task :version_bits => :environment do
+    block = Node.where(coin: "BTC").reorder(version: :desc).first.block
+    while true
+      puts "#{ block.height }: %.32b" % block.version
+      break unless block = block.parent
+    end
+  end
 end

--- a/lib/tasks/blocks.rake
+++ b/lib/tasks/blocks.rake
@@ -12,4 +12,57 @@ namespace 'blocks' do :env
       break unless block = block.parent
     end
   end
+
+  desc "Version bit alerts"
+  task :version_bit_alerts, [:height] => :environment do |action, args|
+    block = Node.where(coin: "BTC").reorder(version: :desc).first.block
+    until_height = args.height.to_i
+
+    versions_window = [0] * 100
+    versions_window_new = [[0] * 32] * 100
+    alerts = 0
+    alerts_new = 0
+    active_alert = false
+    active_alert_new = [false] * 32
+    while block.height >= until_height
+      if !block.version.present?
+        puts "Missing version for block #{ block.height }"
+        exit(1)
+      end
+
+      versions_window.shift()
+      versions_window.push(block.version)
+      if versions_window.collect{|v| 1 && (v & ~0b100000000000000000000000000000)}.sum >= 50 && !active_alert
+        active_alert = true
+        alerts = alerts + 1
+        puts "#{ block.height }: %.32b" % block.version
+      end
+      if active_alert && versions_window.collect{|v| 1 && (v & ~0b100000000000000000000000000000)}.sum == 0
+        active_alert = false
+      end
+
+      versions_window_new.shift()
+      versions_window_new.push(("%.32b" % (block.version & ~0b100000000000000000000000000000)).split("").collect{|s|s.to_i})
+
+      versions_tally = versions_window_new.transpose.map(&:sum)
+      if versions_tally.max >= 10
+        pos = versions_tally.index(versions_tally.max)
+        if !active_alert_new[pos]
+          active_alert_new[pos] = true
+          alerts_new = alerts_new + 1
+          puts "Start alert for version bit #{ 32 - pos - 1 }"
+        end
+      end
+      active_alert_new.each_with_index do |alert, pos|
+        if alert && versions_tally[pos] == 0
+          puts "End alert for version bit #{ 32 - pos - 1 }"
+          active_alert_new[pos] = false
+        end
+      end
+
+      break unless block = block.parent
+    end
+    puts alerts
+    puts alerts_new
+  end
 end

--- a/lib/tasks/blocks.rake
+++ b/lib/tasks/blocks.rake
@@ -15,6 +15,8 @@ namespace 'blocks' do :env
 
   desc "Version bit alerts"
   task :version_bit_alerts, [:height] => :environment do |action, args|
+    threshold = Rails.env.test? ? 2 : ENV['VERSION_BITS_THRESHOLD'] || 50
+
     block = Node.where(coin: "BTC").reorder(version: :desc).first.block
     until_height = args.height.to_i
 
@@ -45,7 +47,7 @@ namespace 'blocks' do :env
       versions_window_new.push(("%.32b" % (block.version & ~0b100000000000000000000000000000)).split("").collect{|s|s.to_i})
 
       versions_tally = versions_window_new.transpose.map(&:sum)
-      if versions_tally.max >= 10
+      if versions_tally.max >= threshold
         pos = versions_tally.index(versions_tally.max)
         if !active_alert_new[pos]
           active_alert_new[pos] = true

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
    factory :user do
      email { FFaker::Internet.email }
-     password { "123456" }
+     password { FFaker::Internet.password }
      confirmed_at { Time.now }
    end
  end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -40,4 +40,20 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
   end
+
+  describe "version bits notify" do
+    let(:user) { create(:user) }
+    let(:node ) { create(:node_with_block, version: 170100) }
+    let(:mail) { UserMailer.with(user: user, bit: 1, tally: 2, window: 3, block: node.block).version_bits_email }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("[ForkMonitor] version bit 1 was set 2 times between blocks #{ node.block.height - 2} and #{ node.block.height }")
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to include("https://forkmonitor.info/nodes/btc")
+    end
+
+  end
 end

--- a/spec/models/version_bit_spec.rb
+++ b/spec/models/version_bit_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe VersionBit, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Send an email notification whenever a version bit has signalled multiple times in the past 100 blocks. Threshold is configureable through `VERSION_BITS_THRESHOLD` and initially set to 10. That will lead to false positives because miners are grinding the version field.