### PR TITLE
fix: don't fetch ancestors below requested height

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -207,11 +207,11 @@ class Node < ApplicationRecord
     end
   end
 
-  def find_block_ancestors!(child_block, until_height)
+  def find_block_ancestors!(child_block, until_height = nil)
     block_id = child_block.id
     loop do
       block = Block.find(block_id)
-      return if block.height == until_height
+      return if until_height && block.height == until_height
       parent = block.parent
       if parent.nil?
         if self.version >= 120000
@@ -222,7 +222,9 @@ class Node < ApplicationRecord
         parent = Block.find_by(block_hash: block_info["previousblockhash"])
         block.update parent: parent
       end
-      if parent.nil?
+      if parent.present?
+        return if until_height.nil?
+      else
         # Fetch parent block, unless:
         # * this is not a BTC node
         break if !self.id || self.coin != "BTC"

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -582,6 +582,30 @@ RSpec.describe Node, :type => :model do
     end
   end
 
+  describe "find_block_ancestors!" do
+    before do
+      @node = build(:node)
+      expect(Block.minimum(:height)).to equal(nil)
+      @node.client.mock_set_height(560179)
+      @node.poll!
+      @node.reload
+      expect(@node.block.height).to equal(560179)
+      expect(Block.minimum(:height)).to equal(560179)
+    end
+
+    it "should fetch parents beyond the oldest block" do
+      @node.client.mock_set_height(560182)
+      @node.poll!
+      @node.reload
+      expect(@node.block.height).to equal(560182)
+      expect(Block.count).to equal(4)
+
+      @node.find_block_ancestors!(@node.block, 560176)
+      expect(Block.count).to equal(7)
+      expect(Block.minimum(:height)).to equal(560176)
+    end
+  end
+
   describe "class" do
     describe "poll!" do
       it "should call poll! on all nodes, followed by check_laggards!, check_chaintips! and check_versionbits!" do


### PR DESCRIPTION
This should make polling quick again.