### PR TITLE
Inflation monitoring - part 1

### DIFF
--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -21,4 +21,20 @@ class Block < ApplicationRecord
     return nil if work.nil?
     Math.log2(work.to_i(16))
   end
+
+  def self.check_inflation!
+    # Use the latest node for this check
+    node = Node.bitcoin_by_version.first
+    throw "Node in Initial Blockchain Download" if node.ibd
+
+    puts "Get the total UTXO balance at the tip..." unless Rails.env.test?
+    # Make sure we have all blocks up to the tip.
+    # TODO: Check that the previous snapshot is a block ancestor, otherwise delete it
+
+    # TODO: Check that inflation does not exceed 12.5 BTC per block (abort this simlified check after halvening)
+
+    # TODO: Process each block and calculate inflation; compare with snapshot.
+
+    # TODO: Send alert if greater than allowed
+  end
 end

--- a/app/models/tx_outset.rb
+++ b/app/models/tx_outset.rb
@@ -1,0 +1,3 @@
+class TxOutset < ApplicationRecord
+  belongs_to :block
+end

--- a/app/services/bitcoin_client.rb
+++ b/app/services/bitcoin_client.rb
@@ -80,6 +80,14 @@ class BitcoinClient
     end
   end
 
+  def gettxoutsetinfo
+    begin
+      return request("gettxoutsetinfo")
+    rescue Bitcoiner::Client::JSONRPCError => e
+      puts "gettxoutsetinfo failed for node #{@id}: " + e.message
+      raise
+    end
+  end
 
   private
 

--- a/app/services/bitcoin_client_mock.rb
+++ b/app/services/bitcoin_client_mock.rb
@@ -215,6 +215,33 @@ class BitcoinClientMock
     @chaintips
   end
 
+  def gettxoutsetinfo
+    if @height == 560176
+      return {
+        "height" => @height, # Actually 572023
+        "bestblock" => @block_hashes[@height],
+        "transactions" => 29221340,
+        "txouts" => 53336961,
+        "bogosize" => 4018808071,
+        "hash_serialized_2" => "9bd2d3a6d6aa32e68f3c48286986a1c8771180f2c46bb316bb0073b194835d6b",
+        "disk_size" => 3202897585,
+        "total_amount" => 17650117.32457854
+      }
+    elsif @height == 560178
+      return {
+        "height" => @height, # Actually 572025,
+        "bestblock" => @block_hashes[@height],
+        "transactions" => 29222816,
+        "txouts" => 53340690,
+        "bogosize" => 4019083859,
+        "hash_serialized_2" => "f970cc0aabb3adff4e18a75460ef58c91eb8a181ec97e0d3d8acb71f55402c0a",
+        "disk_size" => 3147778574,
+        "total_amount" => 17650142.32457854
+      }
+    end
+    throw "No mock txoutset for height #{ @height }"
+  end
+
   def mock_add_block(height, mediantime, chainwork, block_hash=nil, previousblockhash=nil, version=536870912) # versionHex 0x20000000
     block_hash ||= @block_hashes[height]
     previousblockhash ||= @block_hashes[height - 1]

--- a/db/migrate/20190417132856_create_tx_outsets.rb
+++ b/db/migrate/20190417132856_create_tx_outsets.rb
@@ -1,0 +1,11 @@
+class CreateTxOutsets < ActiveRecord::Migration[5.2]
+  def change
+    create_table :tx_outsets do |t|
+      t.references :block, foreign_key: true
+      t.integer :txouts
+      t.decimal :total_amount, :precision => 16, :scale => 8
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_17_112257) do
+ActiveRecord::Schema.define(version: 2019_04_17_132856) do
 
   create_table "blocks", force: :cascade do |t|
     t.string "block_hash"
@@ -79,6 +79,15 @@ ActiveRecord::Schema.define(version: 2019_04_17_112257) do
     t.datetime "notified_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "tx_outsets", force: :cascade do |t|
+    t.integer "block_id"
+    t.integer "txouts"
+    t.decimal "total_amount", precision: 16, scale: 8
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["block_id"], name: "index_tx_outsets_on_block_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/tasks/blocks.rake
+++ b/lib/tasks/blocks.rake
@@ -3,4 +3,9 @@ namespace 'blocks' do :env
   task :fetch_ancestors, [:height] => :environment do |action, args|
     Node.fetch_ancestors!(args.height.to_i)
   end
+
+  desc "Check for unwanted inflation"
+  task :check_inflation => :environment do |action|
+    Block.check_inflation!
+  end
 end

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -9,4 +9,15 @@ RSpec.describe Block, :type => :model do
       expect(block.log2_pow).to eq(1.0)
     end
   end
+
+  describe "self.check_inflation!" do
+    before do
+      @node = build(:node, version: 170001)
+      @node.client.mock_set_height(560176)
+      @node.poll!
+      @node.reload
+      expect(Block.maximum(:height)).to eq(560176)
+      allow(Node).to receive(:bitcoin_by_version).and_return [@node]
+    end
+  end
 end

--- a/spec/models/tx_outset_spec.rb
+++ b/spec/models/tx_outset_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TxOutset, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/services/bitcoin_client_spec.rb
+++ b/spec/services/bitcoin_client_spec.rb
@@ -47,5 +47,12 @@ describe BitcoinClient do
         @client.getblockheader("hash")
       end
     end
+
+    describe "gettxoutsetinfo" do
+      it "should call gettxoutsetinfo rpc method" do
+        expect(@client).to receive(:request).with("gettxoutsetinfo")
+        @client.gettxoutsetinfo
+      end
+    end
   end
 end

--- a/spec/tasks/blocks_rake_spec.rb
+++ b/spec/tasks/blocks_rake_spec.rb
@@ -8,3 +8,12 @@ describe "blocks:fetch_ancestors" do
     subject.invoke("1")
   end
 end
+
+describe "blocks:check_inflation" do
+  include_context "rake"
+
+  it "should call :check_inflation! on Block" do
+    expect(Block).to receive(:check_inflation!)
+    subject.invoke()
+  end
+end


### PR DESCRIPTION
First step towards monitoring inflation is to regularly call the [gettxoutsetinfo](https://bitcoincore.org/en/doc/0.17.0/rpc/blockchain/gettxoutsetinfo/) RPC method. This contains the total BTC in the UTXO set at the latest block. We store this result.

It's a fairly slow RPC call so I'm adding an hourly cron job on Heroku for this.

The next step is to send alert (email & rss) whenever inflation exceeds 12.5 BTC per block (until the next halving).

The final step, in order to make it more precise, would be to parse each block and calculate the inflation based on its transactions.