### PR TITLE
Tool: list chaintips and compare forks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem "rack-timeout"
 # Measure test coverage
 gem 'coveralls', require: false
 
+# Print arrays as a table
+gem 'table_print'
+
 group :development, :test do
   # Use sqlite3 as the database for Active Record
   gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
+    table_print (1.5.6)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     terminal-notifier-guard (1.6.4)
@@ -306,6 +307,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
+  table_print
   terminal-notifier-guard (~> 1.6.1)
   timecop
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -100,3 +100,25 @@ RAILS_ENV=development_pg rake db:migrate
 RAILS_ENV=test_pg rspec
 RAILS_ENV=development_pg rails server
 ```
+
+## Tools
+
+To get a list of chaintips for all nodes run:
+
+```rb
+rake blocks:get_chaintips
+```
+
+```
+Node 1: Bitcoin Core 0.17.99:
+HEIGHT | BRANCHLEN | STATUS        | HASH
+-------|-----------|---------------|-----------------------------------------------------------------
+572319 | 0         | active        | 0000000000000000002671de2c0d7966398eef6c36e5c23706e36f2b6ba34633
+525890 | 1         | valid-headers | 0000000000000000003d068ec400b1042b8d1ed867cf3c380b64ca074c6d12c7
+```
+
+To investigate orphaned blocks (`valid-fork`), use the node id and chaintip hash from above:
+
+```rb
+rake blocks:investigate_chaintip[NODE_ID,CHAINTIP_HASH]
+```

--- a/app/services/bitcoin_client.rb
+++ b/app/services/bitcoin_client.rb
@@ -53,7 +53,7 @@ class BitcoinClient
     end
   end
 
-  def getblock(hash)
+  def getblock(hash, verbosity = 1)
     begin
       return request("getblock", hash)
     rescue Bitcoiner::Client::JSONRPCError => e

--- a/lib/tasks/blocks.rake
+++ b/lib/tasks/blocks.rake
@@ -8,4 +8,18 @@ namespace 'blocks' do :env
   task :check_inflation => :environment do |action|
     Block.check_inflation!
   end
+
+  desc "Get chaintips for all nodes"
+  task :get_chaintips => :environment do |action|
+    Node.all.each do |node|
+      puts "Node #{ node.id }: #{ node.name_with_version }:"
+      tp node.client.getchaintips, :height, :branchlen, :status, :hash => {:width => 64}
+    end
+  end
+
+  desc "Investigate a fork [node_id] [chaintip]"
+  task :investigate_fork, [:node,:chaintip] => :environment do |action, args|
+    @node = Node.find(args.node.to_i)
+    @node.investigate_chaintip(args.chaintip)
+  end
 end


### PR DESCRIPTION
For example for the recent BSV fork:

```sh
rake blocks:get_chaintips
Node 3: Bitcoin SV 10.0.10:
HEIGHT | BRANCHLEN | STATUS        | HASH
-------|-----------|---------------|-----------------------------------------------------------------
578796 | 0         | active        | 00000000000000000982e2f4e3fa2bb07278afa57fe1ee4cfd391ce56d4a51c5
578645 | 6         | valid-fork    | 0000000000000000049efe9a6e674370461c78845b98c4d045fe9cd5cb9ea634
577726 | 1         | valid-headers | 000000000000000000d6c86c2a1930155c755a38baaaac323e8227f9bb91b074
```

```sh
rake blocks:investigate_fork[3,"0000000000000000049efe9a6e674370461c78845b98c4d045fe9cd5cb9ea634"]
...
Main chain transactions            : 754008
Fork transactions                  : 1050743
Overlap (same # blocks)            : 753945
Overlap at tip                     : 1050737
Unique txs main chain (ex coinbase): 13826
Unique txs fork chain (ex coinbase): 0
```

