### PR TITLE
Support bcoin

### DIFF
--- a/app/controllers/api/v1/nodes_controller.rb
+++ b/app/controllers/api/v1/nodes_controller.rb
@@ -55,6 +55,6 @@ class Api::V1::NodesController < ApplicationController
   end
 
   def node_params
-    params.require(:node).permit(:name, :coin, :rpchost, :rpcuser, :rpcpassword, :common_height)
+    params.require(:node).permit(:name, :coin, :is_core, :rpchost, :rpcuser, :rpcpassword, :common_height)
   end
 end

--- a/app/controllers/api/v1/nodes_controller.rb
+++ b/app/controllers/api/v1/nodes_controller.rb
@@ -4,7 +4,8 @@ class Api::V1::NodesController < ApplicationController
 
   # Unauthenticated list of nodes, per coin:
   def index_coin
-    @nodes = Node.where(coin: params[:coin].upcase)
+    @nodes = Node.where(coin: params[:coin].upcase).includes(:block).order("blocks.work desc", is_core: :desc ,name: :asc, version: :desc)
+
     render json: @nodes
   end
 

--- a/app/javascript/packs/forkMonitorApp/components/nodesAdmin.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/nodesAdmin.jsx
@@ -4,12 +4,14 @@ import {
   Edit,
   Create,
   Datagrid,
+  BooleanField,
   TextField,
   DateField,
   NumberField,
   SimpleForm,
   NumberInput,
-  TextInput
+  TextInput,
+  BooleanInput
 } from 'react-admin';
 
 export const NodeList = props => (
@@ -20,6 +22,7 @@ export const NodeList = props => (
             <NumberField source="id" />
             <TextField source="coin" />
             <TextField source="name" />
+            <BooleanField source="is_core" />
             <TextField source="version" />
             <DateField source="unreachable_since" />
             <NumberField source="best_block.height" />
@@ -33,6 +36,7 @@ export const NodeEdit = props => (
         <SimpleForm>
             <TextInput source="coin" />
             <TextInput source="name" />
+            <BooleanInput source="is_core" />
             <TextInput source="rpchost" />
             <TextInput source="rpcuser" />
             <TextInput source="rpcpassword" />
@@ -46,6 +50,7 @@ export const NodeCreate = props => (
         <SimpleForm>
             <TextInput source="coin" />
             <TextInput source="name" />
+            <BooleanInput source="is_core" />
             <TextInput source="rpchost" />
             <TextInput source="rpcuser" />
             <TextInput source="rpcpassword" />

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -24,7 +24,7 @@ class Block < ApplicationRecord
 
   def self.check_inflation!
     # Use the latest node for this check
-    node = Node.bitcoin_by_version.first
+    node = Node.bitcoin_core_by_version.first
     throw "Node in Initial Blockchain Download" if node.ibd
 
     puts "Get the total UTXO balance at the tip..." unless Rails.env.test?

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -4,8 +4,6 @@ class Node < ApplicationRecord
   belongs_to :first_seen_by, foreign_key: "first_seen_by_id", class_name: "Node", required: false
   has_many :invalid_blocks
 
-  default_scope { includes(:block).order("blocks.work desc", name: :asc, version: :desc) }
-
   scope :bitcoin_core_by_version, -> { where(coin: "BTC", is_core: true).reorder(version: :desc) }
   scope :bitcoin_alternative_implementations, -> { where(coin: "BTC", is_core: false) }
 

--- a/app/services/bitcoin_client_mock.rb
+++ b/app/services/bitcoin_client_mock.rb
@@ -114,7 +114,18 @@ class BitcoinClientMock
           "networkactive" => true,
           "connections" => @peer_count,
           "warnings" => ""
-        }
+        },
+        "v1.0.2" => {
+          "version" => "v1.0.2",
+          "subversion" => "/bcoin:v1.0.2/",
+          "protocolversion" => 70015,
+          "localservices" => "00000009",
+          "localrelay" => true,
+          "timeoffset" => 0,
+          "networkactive" => true,
+          "connections" => @peer_count,
+          "warnings" => ""
+        },
       }[@version]
     else
       {
@@ -186,7 +197,21 @@ class BitcoinClientMock
         "bestblockhash" => @block_hashes[@height],
         "verificationprogress" => @ibd ? 0.5 : 1.0,
         "chainwork" => @blocks[@block_hashes[@height]]["chainwork"]
-      }
+      },
+      "v1.0.2" => {
+        "chain" => "main",
+        "blocks" => @height,
+        "headers" => @height,
+        "bestblockhash" => @block_hashes[@height],
+        # "difficulty" => 1,
+        "mediantime" => 1232327230,
+        "verificationprogress" => @ibd ? 1.753483709675226e-06 : 1.0,
+        "chainwork" => @blocks[@block_hashes[@height]]["chainwork"],
+        "pruned" => false,
+        "softforks" => [],
+        "bip9_softforks" => {
+        }
+      },
     }[@version]
   end
 

--- a/db/migrate/20190417085001_add_is_btc_to_blocks.rb
+++ b/db/migrate/20190417085001_add_is_btc_to_blocks.rb
@@ -2,14 +2,14 @@ class AddIsBtcToBlocks < ActiveRecord::Migration[5.2]
   def up
     add_column :blocks, :is_btc, :boolean, default: false
 
-    node = Node.bitcoin_by_version.first
-    if node.present?
-      block = node.block
-      while block.parent.present? do
-        block.update is_btc: true
-        block = block.parent
-      end
-    end
+    # node = Node.bitcoin_by_version.first
+    # if node.present?
+    #   block = node.block
+    #   while block.parent.present? do
+    #     block.update is_btc: true
+    #     block = block.parent
+    #   end
+    # end
 
     add_index :blocks, :is_btc
   end

--- a/db/migrate/20190423103402_add_is_core_to_nodes.rb
+++ b/db/migrate/20190423103402_add_is_core_to_nodes.rb
@@ -1,0 +1,5 @@
+class AddIsCoreToNodes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :nodes, :is_core, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,6 +14,7 @@ ActiveRecord::Schema.define(version: 2019_04_17_132856) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+ActiveRecord::Schema.define(version: 2019_04_23_103402) do
 
   create_table "blocks", force: :cascade do |t|
     t.string "block_hash"
@@ -73,6 +74,7 @@ ActiveRecord::Schema.define(version: 2019_04_17_132856) do
     t.integer "common_height"
     t.boolean "ibd"
     t.integer "peer_count"
+    t.boolean "is_core", default: false
     t.index ["block_id"], name: "index_nodes_on_block_id"
     t.index ["common_block_id"], name: "index_nodes_on_common_block_id"
   end

--- a/spec/factories/nodes.rb
+++ b/spec/factories/nodes.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
    factory :node do
      coin { "BTC"}
      name { "Bitcoin Core" }
+     is_core { true }
    end
 
    factory :node_with_block, parent: :node do

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Block, :type => :model do
       @node.poll!
       @node.reload
       expect(Block.maximum(:height)).to eq(560176)
-      allow(Node).to receive(:bitcoin_by_version).and_return [@node]
+      allow(Node).to receive(:bitcoin_core_by_version).and_return [@node]
     end
 
     it "should call gettxoutsetinfo" do

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe Node, :type => :model do
   describe "version" do
     it "should be set" do
-      node = create(:node_with_block)
-      expect(node.version).not_to eq(0)
+      node = create(:node_with_block, version: 160300)
+      expect(node.version).to eq(160300)
     end
   end
 
@@ -12,6 +12,11 @@ RSpec.describe Node, :type => :model do
     it "should combine node name with version" do
       node = create(:node, version: 170001)
       expect(node.name_with_version).to eq("Bitcoin Core 0.17.0.1")
+    end
+
+    it "should handle 1.0 version" do
+      node = create(:node, version: 1000000)
+      expect(node.name_with_version).to eq("Bitcoin Core 1.0.0")
     end
 
     it "should drop the 4th digit if zero" do
@@ -35,6 +40,12 @@ RSpec.describe Node, :type => :model do
       it "should store the node version" do
         @node.poll!
         expect(@node.version).to eq(170100)
+      end
+
+      it "should parse v1.0.2 variant (e.g. Bcoin)" do
+        @node.client.mock_version("v1.0.2")
+        @node.poll!
+        expect(@node.version).to eq(1000200)
       end
 
       it "should not store the latest block if in IBD" do

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -330,7 +330,7 @@ RSpec.describe Node, :type => :model do
 
       it "should trigger potential orphan alert" do
         expect(User).to receive(:all).twice.and_return [user]
-        expect(Node).to receive(:bitcoin_by_version).twice.and_return [@A, @B]
+        expect(Node).to receive(:bitcoin_core_by_version).twice.and_return [@A, @B]
 
         # One alert for each height:
         expect { Node.check_chaintips! }.to change { ActionMailer::Base.deliveries.count }.by(2)
@@ -664,7 +664,7 @@ RSpec.describe Node, :type => :model do
 
         expect(Node).to receive(:check_chaintips!)
 
-        expect(Node).to receive(:bitcoin_by_version).and_wrap_original {|relation|
+        expect(Node).to receive(:bitcoin_core_by_version).and_wrap_original {|relation|
           relation.call.each {|node|
             expect(node).to receive(:poll!)
             if node.version ==  170000
@@ -695,7 +695,7 @@ RSpec.describe Node, :type => :model do
       end
 
       it "should call check_if_behind! against the newest node" do
-        expect(Node).to receive(:bitcoin_by_version).and_wrap_original {|relation|
+        expect(Node).to receive(:bitcoin_core_by_version).and_wrap_original {|relation|
           relation.call.each {|record|
             if record.id == @A.id
               expect(record).not_to receive(:check_if_behind!)
@@ -720,7 +720,7 @@ RSpec.describe Node, :type => :model do
       end
 
       it "should call check_chaintips! against nodes" do
-        expect(Node).to receive(:bitcoin_by_version).and_wrap_original {|relation|
+        expect(Node).to receive(:bitcoin_core_by_version).and_wrap_original {|relation|
           relation.call.each {|record|
               expect(record).to receive(:check_chaintips!)
           }
@@ -743,7 +743,7 @@ RSpec.describe Node, :type => :model do
       end
 
       it "should call find_block_ancestors! against the newest node" do
-        expect(Node).to receive(:bitcoin_by_version).and_wrap_original {|relation|
+        expect(Node).to receive(:bitcoin_core_by_version).and_wrap_original {|relation|
           relation.call.each {|record|
             if record.id == @A.id
               expect(record).to receive(:find_block_ancestors!)


### PR DESCRIPTION
This adds [bcoin](https://bcoin.io) Bitcoin support. Its RPC is pretty much identical to Bitcoin Core.

When polling nodes, start with Bitcoin Core nodes in descending version order. Then poll alternative implementations.