### PR TITLE
Split BCH and BSV tabs

### DIFF
--- a/app/controllers/api/v1/blocks_controller.rb
+++ b/app/controllers/api/v1/blocks_controller.rb
@@ -6,8 +6,8 @@ class Api::V1::BlocksController < ApplicationController
     @range = JSON.parse(params["range"])
     @offset = @range[0]
     @limit = @range[1]
-    @blocks = Block.where(is_btc: true).order(height: :desc).offset(@offset).limit(@limit)
-    response.headers['Content-Range'] = Block.where(is_btc: true).count
+    @blocks = Block.where(coin: :btc).order(height: :desc).offset(@offset).limit(@limit)
+    response.headers['Content-Range'] = Block.where(coin: :btc).count
     render json: @blocks
   end
 

--- a/app/controllers/api/v1/nodes_controller.rb
+++ b/app/controllers/api/v1/nodes_controller.rb
@@ -56,6 +56,6 @@ class Api::V1::NodesController < ApplicationController
   end
 
   def node_params
-    params.require(:node).permit(:name, :coin, :is_core, :rpchost, :rpcuser, :rpcpassword, :common_height)
+    params.require(:node).permit(:name, :coin, :is_core, :rpchost, :rpcuser, :rpcpassword)
   end
 end

--- a/app/javascript/packs/forkMonitorApp/components/navigation.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/navigation.jsx
@@ -51,7 +51,12 @@ class Navigation extends React.Component {
               </NavItem>
               <NavItem className="NavItem">
                 <LinkContainer to="/nodes/bch">
-                  <NavLink>Bitcoin Cash</NavLink>
+                  <NavLink>Bitcoin Cash ABC</NavLink>
+                </LinkContainer>
+              </NavItem>
+              <NavItem className="NavItem">
+                <LinkContainer to="/nodes/bsv">
+                  <NavLink>Bitcoin Cash SV</NavLink>
                 </LinkContainer>
               </NavItem>
               {

--- a/app/javascript/packs/forkMonitorApp/components/nodes.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/nodes.jsx
@@ -90,11 +90,6 @@ class Nodes extends React.Component {
       return(
         <TabPane align="left" >
           <br />
-          { this.state.coin === "bch" &&
-            <UncontrolledAlert color="info">
-              The last common block between ABC and SV was mined. Height: 556766, Log2(PoW): 87.723, Hash: 00000000000000000102d94fde9bd0807a2cc7582fe85dd6349b73ce4e8d9322 at 17:52 UTC on 15th November 2018
-            </UncontrolledAlert>
-          }
           { (this.state.coin === "btc" && this.state && this.state.invalid_blocks || []).map(function (invalid_block) {
             return (
                 <UncontrolledAlert color="danger" key={invalid_block.id}>

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -35,7 +35,7 @@ class UserMailer < ApplicationMailer
   def orphan_candidate_email
     @user = params[:user]
     @orphan_candidate = params[:orphan_candidate]
-    @blocks = Block.where(is_btc: true, height: @orphan_candidate.height)
+    @blocks = Block.where(coin: :btc, height: @orphan_candidate.height)
 
     mail(
       to: @user.email,

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -3,6 +3,7 @@ class Block < ApplicationRecord
   belongs_to :parent, class_name: 'Block', foreign_key: 'parent_id', optional: true
   has_many :invalid_blocks
   belongs_to :first_seen_by, class_name: 'Node', foreign_key: 'first_seen_by_id', optional: true
+  enum coin: [:btc, :bch, :bsv]
 
   def as_json(options = nil)
     super({ only: [:height, :timestamp] }.merge(options || {})).merge({

--- a/app/services/bitcoin_client_mock.rb
+++ b/app/services/bitcoin_client_mock.rb
@@ -148,94 +148,152 @@ class BitcoinClientMock
           "warnings" => ""
         },
       }[@version]
-    else
+    elsif @coin == "BCH"
       {
-        "version" => 180500,
-        "subversion" => "/Bitcoin ABC:0.18.5(EB32.0)/",
-        "protocolversion" => 70015,
-        "localservices" => "0000000000000024",
-        "localrelay"=> true,
-        "timeoffset"=> 0,
-        "networkactive"=> true,
-        "connections"=> @peer_count,
-        "relayfee" => 1.0e-05,
-        "warnings" => "Warning: Unknown block versions being mined! It's possible unknown rules are in effect"}
+        180500 => {
+          "version" => 180500,
+          "subversion" => "/Bitcoin ABC:0.18.5(EB32.0)/",
+          "protocolversion" => 70015,
+          "localservices" => "0000000000000024",
+          "localrelay"=> true,
+          "timeoffset"=> 0,
+          "networkactive"=> true,
+          "connections"=> @peer_count,
+          "relayfee" => 1.0e-05,
+          "warnings" => "Warning: Unknown block versions being mined! It's possible unknown rules are in effect"
+        }
+      }[@version]
+    else # SV: using the same mock data as ABC for now
+      {
+        180500 => {
+          "version" => 180500,
+          "subversion" => "/Bitcoin ABC:0.18.5(EB32.0)/",
+          "protocolversion" => 70015,
+          "localservices" => "0000000000000024",
+          "localrelay"=> true,
+          "timeoffset"=> 0,
+          "networkactive"=> true,
+          "connections"=> @peer_count,
+          "relayfee" => 1.0e-05,
+          "warnings" => "Warning: Unknown block versions being mined! It's possible unknown rules are in effect"
+        }
+      }[@version]
     end
   end
 
   def getblockchaininfo
     raise Bitcoiner::Client::JSONRPCError if !@reachable
-    raise Bitcoiner::Client::JSONRPCError if @coin == "BTC" && @is_core && @version < 100000
-    {
-      170100 => {
-        "chain" => "main",
-        "blocks" => @height,
-        "headers" => @height,
-        "bestblockhash" => @block_hashes[@height],
-        # "difficulty" => 5883988430955.408,
-        "mediantime" => 1548515214,
-        "verificationprogress" => @ibd ? 1.753483709675226e-06 : 1.0,
-        "initialblockdownload" => @ibd,
-        "chainwork" => @blocks[@block_hashes[@height]]["chainwork"],
-        "size_on_disk" => 229120703086 + (@height - 560179) * 2000000,
-        "pruned" => false,
-        "softforks" => [],
-        "bip9_softforks" => {},
-        "warnings" => ""
-      },
-      160300 => {
-        "chain" => "main",
-        "blocks" => @height,
-        "headers" => @height,
-        "bestblockhash" => @block_hashes[@height],
-        # "difficulty" => 5883988430955.408,
-        "mediantime" => 1548515214,
-        "verificationprogress" => @ibd ? 1.753483709675226e-06 : 1.0,
-        "initialblockdownload" => @ibd,
-        "chainwork" => @blocks[@block_hashes[@height]]["chainwork"],
-        "size_on_disk" => 229120703086 + (@height - 560179) * 2000000,
-        "pruned" => false,
-        "softforks" => [],
-        "bip9_softforks" => {},
-        "warnings" => ""
-      },
-      130000 => {
-        "chain" => "main",
-        "blocks" => @height,
-        "headers" => @height,
-        "bestblockhash" => @block_hashes[@height],
-        # "difficulty" => 1,
-        "mediantime" => 1232327230,
-        "verificationprogress" => @ibd ? 1.753483709675226e-06 : 1.0,
-        "chainwork" => @blocks[@block_hashes[@height]]["chainwork"],
-        "pruned" => false,
-        "softforks" => [],
-        "bip9_softforks" => {
+    if @coin == "BTC"
+      raise Bitcoiner::Client::JSONRPCError if @is_core && @version < 100000
+      {
+        170100 => {
+          "chain" => "main",
+          "blocks" => @height,
+          "headers" => @height,
+          "bestblockhash" => @block_hashes[@height],
+          # "difficulty" => 5883988430955.408,
+          "mediantime" => 1548515214,
+          "verificationprogress" => @ibd ? 1.753483709675226e-06 : 1.0,
+          "initialblockdownload" => @ibd,
+          "chainwork" => @blocks[@block_hashes[@height]]["chainwork"],
+          "size_on_disk" => 229120703086 + (@height - 560179) * 2000000,
+          "pruned" => false,
+          "softforks" => [],
+          "bip9_softforks" => {},
+          "warnings" => ""
+        },
+        160300 => {
+          "chain" => "main",
+          "blocks" => @height,
+          "headers" => @height,
+          "bestblockhash" => @block_hashes[@height],
+          # "difficulty" => 5883988430955.408,
+          "mediantime" => 1548515214,
+          "verificationprogress" => @ibd ? 1.753483709675226e-06 : 1.0,
+          "initialblockdownload" => @ibd,
+          "chainwork" => @blocks[@block_hashes[@height]]["chainwork"],
+          "size_on_disk" => 229120703086 + (@height - 560179) * 2000000,
+          "pruned" => false,
+          "softforks" => [],
+          "bip9_softforks" => {},
+          "warnings" => ""
+        },
+        130000 => {
+          "chain" => "main",
+          "blocks" => @height,
+          "headers" => @height,
+          "bestblockhash" => @block_hashes[@height],
+          # "difficulty" => 1,
+          "mediantime" => 1232327230,
+          "verificationprogress" => @ibd ? 1.753483709675226e-06 : 1.0,
+          "chainwork" => @blocks[@block_hashes[@height]]["chainwork"],
+          "pruned" => false,
+          "softforks" => [],
+          "bip9_softforks" => {
+          }
+        },
+        100300 => {
+          "chain" => "main",
+          "blocks" => @height,
+          "headers" => @height,
+          "bestblockhash" => @block_hashes[@height],
+          "verificationprogress" => @ibd ? 0.5 : 1.0,
+          "chainwork" => @blocks[@block_hashes[@height]]["chainwork"]
+        },
+        "v1.0.2" => {
+          "chain" => "main",
+          "blocks" => @height,
+          "headers" => @height,
+          "bestblockhash" => @block_hashes[@height],
+          # "difficulty" => 1,
+          "mediantime" => 1232327230,
+          "verificationprogress" => @ibd ? 1.753483709675226e-06 : 1.0,
+          "chainwork" => @blocks[@block_hashes[@height]]["chainwork"],
+          "pruned" => false,
+          "softforks" => [],
+          "bip9_softforks" => {
+          }
+        },
+      }[@version]
+    elsif @coin == "BCH"
+      {
+        180500 => { # Copied from BTC
+          "chain" => "main",
+          "blocks" => @height,
+          "headers" => @height,
+          "bestblockhash" => @block_hashes[@height],
+          # "difficulty" => 5883988430955.408,
+          "mediantime" => 1548515214,
+          "verificationprogress" => @ibd ? 1.753483709675226e-06 : 1.0,
+          "initialblockdownload" => @ibd,
+          "chainwork" => @blocks[@block_hashes[@height]]["chainwork"],
+          "size_on_disk" => 229120703086 + (@height - 560179) * 2000000,
+          "pruned" => false,
+          "softforks" => [],
+          "bip9_softforks" => {},
+          "warnings" => ""
         }
-      },
-      100300 => {
-        "chain" => "main",
-        "blocks" => @height,
-        "headers" => @height,
-        "bestblockhash" => @block_hashes[@height],
-        "verificationprogress" => @ibd ? 0.5 : 1.0,
-        "chainwork" => @blocks[@block_hashes[@height]]["chainwork"]
-      },
-      "v1.0.2" => {
-        "chain" => "main",
-        "blocks" => @height,
-        "headers" => @height,
-        "bestblockhash" => @block_hashes[@height],
-        # "difficulty" => 1,
-        "mediantime" => 1232327230,
-        "verificationprogress" => @ibd ? 1.753483709675226e-06 : 1.0,
-        "chainwork" => @blocks[@block_hashes[@height]]["chainwork"],
-        "pruned" => false,
-        "softforks" => [],
-        "bip9_softforks" => {
+      }[@version]
+    else # BSV
+      {
+        180500 => { # Copied from BTC
+          "chain" => "main",
+          "blocks" => @height,
+          "headers" => @height,
+          "bestblockhash" => @block_hashes[@height],
+          # "difficulty" => 5883988430955.408,
+          "mediantime" => 1548515214,
+          "verificationprogress" => @ibd ? 1.753483709675226e-06 : 1.0,
+          "initialblockdownload" => @ibd,
+          "chainwork" => @blocks[@block_hashes[@height]]["chainwork"],
+          "size_on_disk" => 229120703086 + (@height - 560179) * 2000000,
+          "pruned" => false,
+          "softforks" => [],
+          "bip9_softforks" => {},
+          "warnings" => ""
         }
-      },
-    }[@version]
+      }[@version]
+    end
   end
 
   def getblockhash(height)

--- a/app/views/feeds/orphan_candidates.rss.builder
+++ b/app/views/feeds/orphan_candidates.rss.builder
@@ -8,8 +8,8 @@ xml.rss :version => "2.0" do
 
     @orphan_candidates.each do |orphan_candidate|
       xml.item do
-        xml.title "There are #{ Block.where(is_btc: true, height: orphan_candidate.height).count } distinct blocks at height #{ orphan_candidate.height }"
-        xml.description "Blocks: #{ Block.where(is_btc: true, height: orphan_candidate.height).collect {|block| block.block_hash }.join(', ')}"
+        xml.title "There are #{ Block.where(coin: :btc, height: orphan_candidate.height).count } distinct blocks at height #{ orphan_candidate.height }"
+        xml.description "Blocks: #{ Block.where(coin: :btc, height: orphan_candidate.height).collect {|block| block.block_hash }.join(', ')}"
         xml.pubDate orphan_candidate.created_at.to_s(:rfc822)
         xml.link api_v1_orphan_candidate_url(orphan_candidate)
         xml.guid api_v1_orphan_candidate_url(orphan_candidate)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,5 +32,6 @@ Rails.application.routes.draw do
 
   get 'nodes/btc', to: "pages#root"
   get 'nodes/bch', to: "pages#root"
+  get 'nodes/bsv', to: "pages#root"
   get 'admin', to: "pages#root"
 end

--- a/db/migrate/20190429093744_remove_common_height_from_nodes.rb
+++ b/db/migrate/20190429093744_remove_common_height_from_nodes.rb
@@ -1,0 +1,6 @@
+class RemoveCommonHeightFromNodes < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :nodes, :common_height
+    remove_column :nodes, :common_block_id
+  end
+end

--- a/db/migrate/20190429100124_add_coin_to_blocks.rb
+++ b/db/migrate/20190429100124_add_coin_to_blocks.rb
@@ -1,0 +1,24 @@
+class AddCoinToBlocks < ActiveRecord::Migration[5.2]
+  def up
+    add_column :blocks, :coin, :integer
+    Block.where(is_btc: true).update_all(coin: :btc)
+    add_index :blocks, :coin
+    remove_column :blocks, :is_btc
+
+    # Be sure to change nodes.coin from "BCH" to "BSV" first!
+    Node.where(coin: "BCH").each do |node|
+      Block.where(first_seen_by_id: node.id).update_all(coin: :bch)
+    end
+
+    Node.where(coin: "BSV").each do |node|
+      Block.where(first_seen_by_id: node.id).update_all(coin: :bsv)
+    end
+  end
+
+  def down
+    add_column :blocks, :is_btc, :bool
+    Block.where(coin: :btc).update_all(is_btc: true)
+    remove_index :blocks, :coin
+    remove_column :blocks, :coin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_17_132856) do
+ActiveRecord::Schema.define(version: 2019_04_29_100124) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-ActiveRecord::Schema.define(version: 2019_04_23_103402) do
 
   create_table "blocks", force: :cascade do |t|
     t.string "block_hash"
@@ -27,10 +26,10 @@ ActiveRecord::Schema.define(version: 2019_04_23_103402) do
     t.integer "mediantime"
     t.bigint "first_seen_by_id"
     t.integer "version"
-    t.boolean "is_btc", default: false
+    t.integer "coin"
     t.index ["block_hash"], name: "index_blocks_on_block_hash", unique: true
+    t.index ["coin"], name: "index_blocks_on_coin"
     t.index ["first_seen_by_id"], name: "index_blocks_on_first_seen_by_id"
-    t.index ["is_btc"], name: "index_blocks_on_is_btc"
     t.index ["parent_id"], name: "index_blocks_on_parent_id"
   end
 
@@ -67,16 +66,13 @@ ActiveRecord::Schema.define(version: 2019_04_23_103402) do
     t.datetime "updated_at", null: false
     t.datetime "unreachable_since"
     t.string "coin"
-    t.bigint "common_block_id"
     t.string "rpchost"
     t.string "rpcuser"
     t.string "rpcpassword"
-    t.integer "common_height"
     t.boolean "ibd"
     t.integer "peer_count"
     t.boolean "is_core", default: false
     t.index ["block_id"], name: "index_nodes_on_block_id"
-    t.index ["common_block_id"], name: "index_nodes_on_common_block_id"
   end
 
   create_table "orphan_candidates", force: :cascade do |t|

--- a/spec/factories/blocks.rb
+++ b/spec/factories/blocks.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
      sequence(:height) { |n| 500000 + n }
      sequence(:timestamp) { |n| 1500000000 * 60 * 10 }
      sequence(:work) { |n| n.to_s(16).rjust(32,"0") }
-     is_btc { true }
+     coin { :btc }
    end
 
    factory :block_first_seen_by, parent: :block do


### PR DESCRIPTION
<img width="397" alt="Schermafbeelding 2019-04-29 om 13 04 06" src="https://user-images.githubusercontent.com/10217/56892236-499e1b00-6a7f-11e9-98b1-fb96227ff568.png">
Remove split information. Also fetch intermediate blocks for BCH/BSV.

Part of #34

Main purpose of this PR is to modify the database. UI tweaks can go in a followup.