### PR TITLE
Track chaintips

### DIFF
--- a/app/controllers/api/v1/chaintips_controller.rb
+++ b/app/controllers/api/v1/chaintips_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::ChaintipsController < ApplicationController
+  def index_coin
+    @chaintips = Chaintip.where(status: "active", coin: params[:coin].downcase, parent_chaintip: nil).includes(:block).order("blocks.work desc", "parent_chaintip_id desc")
+
+    render json: @chaintips.uniq{ |s| s.block.block_hash }
+  end
+end

--- a/app/controllers/api/v1/nodes_controller.rb
+++ b/app/controllers/api/v1/nodes_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::NodesController < ApplicationController
 
   # Unauthenticated list of nodes, per coin:
   def index_coin
-    @nodes = Node.where(coin: params[:coin].upcase).includes(:block).order("blocks.work desc", client_type: :asc ,name: :asc, version: :desc)
+    @nodes = Node.where(coin: params[:coin].upcase).order(client_type: :asc ,name: :asc, version: :desc)
 
     render json: @nodes
   end

--- a/app/javascript/packs/forkMonitorApp/components/chaintip.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/chaintip.jsx
@@ -30,19 +30,19 @@ class Chaintip extends React.Component {
         <Row><Col>
           <Breadcrumb>
             <BreadcrumbItem active className="chaintip-hash">
-              Chaintip: { this.state.chaintip.hash }
+              Chaintip: { this.state.chaintip.block.hash }
             </BreadcrumbItem>
           </Breadcrumb>
           <p>
-            Height: <NumberFormat value={ this.state.chaintip.height } displayType={'text'} thousandSeparator={true} /> (<Moment format="YYYY-MM-DD HH:mm:ss" parse="X">{this.state.chaintip.timestamp}</Moment> UTC)
+            Height: <NumberFormat value={ this.state.chaintip.block.height } displayType={'text'} thousandSeparator={true} /> (<Moment format="YYYY-MM-DD HH:mm:ss" parse="X">{this.state.chaintip.block.timestamp}</Moment> UTC)
             <br/>
-            Accumulated log2(PoW): <NumberFormat value={this.state.chaintip.work} displayType={'text'} decimalScale={6} fixedDecimalScale={true} />
+            Accumulated log2(PoW): <NumberFormat value={this.state.chaintip.block.work} displayType={'text'} decimalScale={6} fixedDecimalScale={true} />
           </p>
           Nodes:
           <ul>
-          {this.state.nodes.filter(o => o.best_block && o.best_block.hash == this.state.chaintip.hash).map(function (node, index) {
+          {this.state.chaintip.nodes.map(function (node, index) {
             return (
-              <Node node={ node } key={node.id} className="pull-left node-info" />
+              <Node node={ node } key={node.id} chaintip={ this.state.chaintip } className="pull-left node-info" />
             )
           }.bind(this))}
           </ul>

--- a/app/javascript/packs/forkMonitorApp/components/node.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/node.jsx
@@ -26,6 +26,10 @@ class Node extends React.Component {
           <NodeName node={this.props.node} />
           <span> {badge}</span>
         </b>
+        {
+            this.props.chaintip && this.props.node.height && this.props.node.height < this.props.chaintip.block.height &&
+            <span> ({ this.props.chaintip.block.height - this.props.node.height } blocks behind)</span>
+        }
       </li>
     )
   }

--- a/app/javascript/packs/forkMonitorApp/components/nodesAdmin.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/nodesAdmin.jsx
@@ -42,7 +42,6 @@ export const NodeList = props => (
             <TextField source="name"/>
             <TextField source="version" />
             <DateField source="unreachable_since" />
-            <NumberField source="best_block.height" />
         </Datagrid>
     </List>
 );

--- a/app/models/chaintip.rb
+++ b/app/models/chaintip.rb
@@ -1,0 +1,72 @@
+class Chaintip < ApplicationRecord
+  belongs_to :block
+  belongs_to :node
+  belongs_to :parent_chaintip, class_name: 'Chaintip', foreign_key: 'parent_chaintip_id', optional: true  # When a node is behind, we assume it would agree with this chaintip, until getchaintips says otherwise
+
+  enum coin: [:btc, :bch, :bsv]
+
+  validates :status, uniqueness: { scope: :node}
+
+  def nodes
+    res = Node.where(block: self.block).to_a # block.node should be the same as the active chaintip for a node
+    Chaintip.where(status: "active", parent_chaintip: self).each do |child|
+      res.append child.node
+    end
+    res
+  end
+
+  def as_json(options = nil)
+    fields = [:id]
+    super({ only: fields }.merge(options || {})).merge({block: block, nodes: nodes})
+  end
+
+  def self.process_chaintip_result(chaintip, node)
+    block = Block.find_by(block_hash: chaintip["hash"], coin: node.coin.downcase.to_sym)
+    case chaintip["status"]
+    when "active"
+      throw "Block missing for active chaintips, did you forget to call poll! ?" unless block.present?
+      tip = node.chaintips.find_or_create_by(status: "active", coin: block.coin) # There can only be one
+      tip.update block: block, parent_chaintip: nil
+      # Check if any of the other nodes are ahead of us. Use their chaintip instead unless we consider it invalid:
+      Chaintip.joins(:block).where(coin: tip.coin, status: "active").where("blocks.height > ?", block.height).each do |candidate_tip|
+        break if node.chaintips.find_by(block: candidate_tip.block, status: "invalid")
+        # Travers candidate tip down to find our tip
+        parent = candidate_tip.block.parent
+        while parent.present? && parent.height >= block.height
+          if parent == block
+            tip.update parent_chaintip: candidate_tip
+            break
+          end
+          parent = parent.parent
+        end
+        break if tip.parent_chaintip
+      end
+    when "valid-fork"
+      return nil if chaintip["height"] < node.block.height - 1000
+      block = Block.find_or_create_block_and_ancestors!(chaintip["hash"], node)
+      tip = node.chaintips.create(status: "valid-fork", block: block, coin: block.coin) # There can be multiple valid-block chaintips
+    when "invalid"
+      # Ignore if we don't know this block from a different node: (TODO: add it anyway, so we actively search this block)
+      return nil if block.nil?
+
+      tip = node.chaintips.create(status: "invalid", block: block, coin: block.coin)
+
+      # Create an alert
+      invalid_block = InvalidBlock.find_or_create_by(node: node, block: block)
+      if !invalid_block.notified_at
+        User.all.each do |user|
+          UserMailer.with(user: user, invalid_block: invalid_block).invalid_block_email.deliver
+        end
+        invalid_block.update notified_at: Time.now
+      end
+    end
+  end
+
+  def self.process_getchaintips(chaintips, node)
+     # Delete existing chaintip entries, except the active one (which is unique):
+     node.chaintips.where.not(status: "active").delete_all
+     chaintips.each do |chaintip|
+       process_chaintip_result(chaintip, node)
+     end
+   end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   namespace :api, {format: 'json'} do
     namespace :v1 do
       match '/nodes/coin/:coin', :to => 'nodes#index_coin', :as => "nodes_for_coin", :via => :get
+      match '/chaintips/:coin', :to => 'chaintips#index_coin', :as => "chaintips_for_coin", :via => :get
       resources :nodes, only: [:index, :show, :update, :destroy, :create]
       resources :invalid_blocks, only: [:index, :show]
       resources :lagging_nodes, only: [:show]

--- a/db/migrate/20190617153641_create_chaintips.rb
+++ b/db/migrate/20190617153641_create_chaintips.rb
@@ -1,0 +1,17 @@
+class CreateChaintips < ActiveRecord::Migration[5.2]
+  def up
+    create_table :chaintips do |t|
+      t.references :node, foreign_key: true
+      t.references :block, foreign_key: true
+      t.references :parent_chaintip,foreign_key: { to_table: :chaintips }
+      t.integer :coin, null: false
+      t.string :status, null: false
+
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :chaintips
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_12_133722) do
+ActiveRecord::Schema.define(version: 2019_06_17_153641) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "blocks", force: :cascade do |t|
     t.string "block_hash"
@@ -28,6 +31,19 @@ ActiveRecord::Schema.define(version: 2019_06_12_133722) do
     t.index ["coin"], name: "index_blocks_on_coin"
     t.index ["first_seen_by_id"], name: "index_blocks_on_first_seen_by_id"
     t.index ["parent_id"], name: "index_blocks_on_parent_id"
+  end
+
+  create_table "chaintips", force: :cascade do |t|
+    t.bigint "node_id"
+    t.bigint "block_id"
+    t.bigint "parent_chaintip_id"
+    t.integer "coin", null: false
+    t.string "status", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["block_id"], name: "index_chaintips_on_block_id"
+    t.index ["node_id"], name: "index_chaintips_on_node_id"
+    t.index ["parent_chaintip_id"], name: "index_chaintips_on_parent_chaintip_id"
   end
 
   create_table "invalid_blocks", force: :cascade do |t|
@@ -58,7 +74,6 @@ ActiveRecord::Schema.define(version: 2019_06_12_133722) do
   create_table "nodes", force: :cascade do |t|
     t.string "name"
     t.integer "version"
-    t.integer "block_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "unreachable_since"
@@ -70,6 +85,7 @@ ActiveRecord::Schema.define(version: 2019_06_12_133722) do
     t.integer "peer_count"
     t.integer "client_type"
     t.integer "rpcport"
+    t.integer "block_id"
     t.index ["block_id"], name: "index_nodes_on_block_id"
   end
 
@@ -116,4 +132,7 @@ ActiveRecord::Schema.define(version: 2019_06_12_133722) do
     t.index ["deactivate_block_id"], name: "index_version_bits_on_deactivate_block_id"
   end
 
+  add_foreign_key "chaintips", "blocks"
+  add_foreign_key "chaintips", "chaintips", column: "parent_chaintip_id"
+  add_foreign_key "chaintips", "nodes"
 end

--- a/spec/models/chaintip_spec.rb
+++ b/spec/models/chaintip_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Chaintip, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/test/javascript/chaintip.test.js
+++ b/test/javascript/chaintip.test.js
@@ -7,46 +7,30 @@ configure({ adapter: new Adapter() });
 
 import Chaintip from 'forkMonitorApp/components/chaintip';
 
+
+const mockNodes = [
+    {id: 1, name: "Bitcoin Core", version: 170100, height: 500000, unreachable_since: null, ibd: false},
+    {id: 2, name: "Bitcoin Core", version: 160300, height: 500000, unreachable_since: null, ibd: false}
+]
+
+const chaintip = {
+    block: {
+        hash: "abcd",
+        height: 500000,
+        timestamp: 1,
+        work: 86.000001
+    },
+    nodes: mockNodes
+}
+
 test('rendered component', () => {
-  const chaintip = {
-    hash: "abcd",
-    height: 500000,
-    timestamp: 1,
-    work: 86.000001
-  }
-  const nodes = [
-    {id: 1, name: "Bitcoin Core", version: 170100, best_block: chaintip, unreachable_since: null, ibd: false},
-    {id: 2, name: "Bitcoin Core", version: 160300, best_block: chaintip, unreachable_since: null, ibd: false}
-  ]
 
   const wrapper = shallow(<Chaintip
     key={ chaintip.hash }
     chaintip={ chaintip }
-    nodes={ nodes }
+    nodes={ mockNodes }
     index={ 0 }
     last={ true }
   />);
   expect(wrapper.find('.node-info')).toHaveLength(2);
-});
-
-test('can handle node without chaintip', () => {
-  const chaintip = {
-    hash: "abcd",
-    height: 500000,
-    timestamp: 1,
-    work: 86.000001
-  }
-  const nodes = [
-    {id: 1, name: "Bitcoin Core", version: 170100, best_block: null, unreachable_since: null, ibd: false},
-    {id: 2, name: "Bitcoin Core", version: 160300, best_block: chaintip, unreachable_since: null, ibd: false}
-  ]
-
-  const wrapper = shallow(<Chaintip
-    key={ chaintip.hash }
-    chaintip={ chaintip }
-    nodes={ nodes }
-    index={ 0 }
-    last={ true }
-  />);
-  expect(wrapper.find('.node-info')).toHaveLength(1);
 });

--- a/test/javascript/nodes.test.js
+++ b/test/javascript/nodes.test.js
@@ -23,8 +23,12 @@ const best_block = {
 }
 
 const mockNodes = [
-  {id: 1, name: "Bitcoin Core", version: 170100, best_block: best_block, unreachable_since: null, ibd: false},
-  {id: 2, name: "Bitcoin Core", version: 160300, best_block: best_block, unreachable_since: null, ibd: false}
+  {id: 1, name: "Bitcoin Core", version: 170100, height: best_block.height, unreachable_since: null, ibd: false},
+  {id: 2, name: "Bitcoin Core", version: 160300, height: best_block.height, unreachable_since: null, ibd: false}
+]
+
+const mockChaintips = [
+  {id: 1, block: best_block, nodes: mockNodes},
 ]
 
 axios.get.mockImplementation(url => {
@@ -34,11 +38,12 @@ axios.get.mockImplementation(url => {
     return Promise.resolve({data: [
       {id: 1, block: {height:582689, timestamp:1558050809, hash: "00000000000000000b6f077cdfc57a62be57c757ec9f8d88d4c2ef8dfc69b141", first_seen_by: {id:3,name:"Bitcoin SV",version:100010000}},"node":{id:21,name:"Bitcoin Unlimited",version:1060000}}
     ]})
+  } else if (url == "/api/v1/chaintips/BTC") {
+     return Promise.resolve({data: mockChaintips})
   } else {
-    throw(false)
+      return Promise.reject({})
   }
-
-})
+});
 
 test('rendered component', async () => {
   const wrapper = shallow(<Nodes match={{params: {coin: 'BTC'}}} />);
@@ -54,12 +59,7 @@ test('can handle node without best block', async () => {
     timestamp: 1,
     work: 86.000001
   }
-  mockNodes[0].best_block = null
-  // const resp = {data: [
-  //   {id: 1, name: "Bitcoin Core", version: 170100, best_block: null, unreachable_since: null, ibd: false},
-  //   {id: 2, name: "Bitcoin Core", version: 160300, best_block: best_block, unreachable_since: null, ibd: false}
-  // ]}
-  // axios.get.mockResolvedValue(resp);
+  mockNodes[0].height = null
 
   const wrapper = shallow(<Nodes match={{params: {coin: 'BTC'}}} />);
   await flushPromises();


### PR DESCRIPTION
Work in progress. I'm refactoring the way we track chaintips. This should make it easier to distinguish nodes that are just behind, from nodes that are out of consensus. See screenshot: 

<img width="747" alt="Schermafbeelding 2019-06-17 om 17 50 33" src="https://user-images.githubusercontent.com/10217/59639221-966dac00-9128-11e9-95f9-94fe10f7dd2d.png">
