### PR TITLE
Additional node fields, nodes can be disabled 

### DIFF
--- a/app/controllers/api/v1/nodes_controller.rb
+++ b/app/controllers/api/v1/nodes_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::NodesController < ApplicationController
 
   # Authenticated list of nodes, for all coins
   def index
-    @nodes = Node.all
+    @nodes = Node.admin
     response.headers['Content-Range'] = @nodes.count
     render json: @nodes.reorder(id: :asc).as_json(admin: true)
   end
@@ -52,10 +52,10 @@ class Api::V1::NodesController < ApplicationController
   private
 
   def set_node
-    @node = Node.find(params[:id])
+    @node = Node.admin.find(params[:id])
   end
 
   def node_params
-    params.require(:node).permit(:name, :coin, :client_type, :version_extra, :rpchost, :rpcport, :rpcuser, :rpcpassword, :pruned, :os, :cpu, :ram, :storage, :cve_2018_17144, :released)
+    params.require(:node).permit(:name, :coin, :client_type, :version_extra, :rpchost, :rpcport, :rpcuser, :rpcpassword, :pruned, :os, :cpu, :ram, :storage, :cve_2018_17144, :released, :enabled)
   end
 end

--- a/app/controllers/api/v1/nodes_controller.rb
+++ b/app/controllers/api/v1/nodes_controller.rb
@@ -56,6 +56,6 @@ class Api::V1::NodesController < ApplicationController
   end
 
   def node_params
-    params.require(:node).permit(:name, :coin, :client_type, :version_extra, :rpchost, :rpcport, :rpcuser, :rpcpassword)
+    params.require(:node).permit(:name, :coin, :client_type, :version_extra, :rpchost, :rpcport, :rpcuser, :rpcpassword, :pruned, :os, :cpu, :ram, :storage, :cve_2018_17144, :released)
   end
 end

--- a/app/javascript/packs/forkMonitorApp/components/nodesAdmin.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/nodesAdmin.jsx
@@ -47,9 +47,8 @@ export const NodeList = props => (
 export const NodeEdit = props => (
     <Edit {...props}>
         <SimpleForm>
-            <SelectInput source="coin" choices={ coin_choices } />
-            <TextInput source="name" />
-            <SelectInput source="client_type" choices={ client_choices } />
+            <TextField source="coin" />
+            <TextField source="name_with_version" readOnly />
             <TextInput source="version_extra" />
             <TextInput source="rpchost" />
             <NumberInput source="rpcport" />

--- a/app/javascript/packs/forkMonitorApp/components/nodesAdmin.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/nodesAdmin.jsx
@@ -11,7 +11,9 @@ import {
   SimpleForm,
   NumberInput,
   TextInput,
-  SelectInput
+  SelectInput,
+  BooleanInput,
+  DateInput,
 } from 'react-admin';
 
 const coin_choices = [
@@ -54,6 +56,13 @@ export const NodeEdit = props => (
             <NumberInput source="rpcport" />
             <TextInput source="rpcuser" />
             <TextInput source="rpcpassword" />
+            <BooleanInput source="pruned" />
+            <TextInput source="os" />
+            <TextInput source="cpu" />
+            <NumberInput source="ram" />
+            <TextInput source="storage" />
+            <BooleanInput source="cve_2018_17144" />
+            <DateInput source="released" />
         </SimpleForm>
     </Edit>
 );
@@ -69,6 +78,13 @@ export const NodeCreate = props => (
             <NumberInput source="rpcport" />
             <TextInput source="rpcuser" />
             <TextInput source="rpcpassword" />
+            <BooleanInput source="pruned" />
+            <TextInput source="os" />
+            <TextInput source="cpu" />
+            <NumberInput source="ram" />
+            <TextInput source="storage" />
+            <BooleanInput source="cve_2018_17144" />
+            <DateInput source="released" />
         </SimpleForm>
     </Create>
 );

--- a/app/javascript/packs/forkMonitorApp/components/nodesAdmin.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/nodesAdmin.jsx
@@ -42,6 +42,7 @@ export const NodeList = props => (
             <TextField source="coin" />
             <TextField source="name_with_version" />
             <DateField source="unreachable_since" />
+            <BooleanField source="enabled" />
         </Datagrid>
     </List>
 );
@@ -63,6 +64,7 @@ export const NodeEdit = props => (
             <TextInput source="storage" />
             <BooleanInput source="cve_2018_17144" />
             <DateInput source="released" />
+            <BooleanInput source="enabled" />
         </SimpleForm>
     </Edit>
 );

--- a/app/javascript/packs/forkMonitorApp/components/nodesAdmin.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/nodesAdmin.jsx
@@ -38,9 +38,7 @@ export const NodeList = props => (
         <Datagrid rowClick="edit">
             <NumberField source="id" />
             <TextField source="coin" />
-            <TextField source="client_type" />
-            <TextField source="name"/>
-            <TextField source="version_extra" />
+            <TextField source="name_with_version" />
             <DateField source="unreachable_since" />
         </Datagrid>
     </List>

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -33,7 +33,7 @@ class Node < ApplicationRecord
   end
 
   def as_json(options = nil)
-    fields = [:id, :unreachable_since, :ibd, :client_type]
+    fields = [:id, :unreachable_since, :ibd, :client_type, :pruned, :os, :cpu, :ram, :storage, :cve_2018_17144, :released]
     if options && options[:admin]
       fields << :id << :coin << :rpchost << :rpcport << :rpcuser << :rpcpassword << :version_extra << :name
     end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -4,6 +4,10 @@ class Node < ApplicationRecord
   has_many :blocks_first_seen, class_name: "Block", foreign_key: "first_seen_by_id", dependent: :nullify
   has_many :invalid_blocks
 
+  default_scope { where(enabled: true) }
+
+  scope :admin, -> { unscope(:where) }
+
   scope :bitcoin_core_by_version, -> { where(coin: "BTC", client_type: :core).where.not(version: nil).order(version: :desc) }
   scope :bitcoin_core_unknown_version, -> { where(coin: "BTC", client_type: :core).where(version: nil) }
   scope :bitcoin_alternative_implementations, -> { where(coin: "BTC"). where.not(client_type: :core) }
@@ -35,7 +39,7 @@ class Node < ApplicationRecord
   def as_json(options = nil)
     fields = [:id, :unreachable_since, :ibd, :client_type, :pruned, :os, :cpu, :ram, :storage, :cve_2018_17144, :released]
     if options && options[:admin]
-      fields << :id << :coin << :rpchost << :rpcport << :rpcuser << :rpcpassword << :version_extra << :name
+      fields << :id << :coin << :rpchost << :rpcport << :rpcuser << :rpcpassword << :version_extra << :name << :enabled
     end
     super({ only: fields }.merge(options || {})).merge({height: block && block.height, name_with_version: name_with_version})
   end

--- a/db/migrate/20190807090722_add_info_to_nodes.rb
+++ b/db/migrate/20190807090722_add_info_to_nodes.rb
@@ -1,0 +1,11 @@
+class AddInfoToNodes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :nodes, :pruned, :boolean, default: false, null: false
+    add_column :nodes, :os, :string
+    add_column :nodes, :cpu, :string
+    add_column :nodes, :ram, :integer
+    add_column :nodes, :storage, :string
+    add_column :nodes, :cve_2018_17144, :boolean, default: false, null: false
+    add_column :nodes, :released, :date
+  end
+end

--- a/db/migrate/20190807094519_add_enabled_to_nodes.rb
+++ b/db/migrate/20190807094519_add_enabled_to_nodes.rb
@@ -1,0 +1,5 @@
+class AddEnabledToNodes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :nodes, :enabled, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_07_090722) do
+ActiveRecord::Schema.define(version: 2019_08_07_094519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -97,6 +97,7 @@ ActiveRecord::Schema.define(version: 2019_08_07_090722) do
     t.string "storage"
     t.boolean "cve_2018_17144", default: false, null: false
     t.date "released"
+    t.boolean "enabled", default: true, null: false
     t.index ["block_id"], name: "index_nodes_on_block_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_16_132643) do
+ActiveRecord::Schema.define(version: 2019_08_07_090722) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,6 +90,13 @@ ActiveRecord::Schema.define(version: 2019_07_16_132643) do
     t.integer "rpcport"
     t.integer "block_id"
     t.string "version_extra", default: "", null: false
+    t.boolean "pruned", default: false, null: false
+    t.string "os"
+    t.string "cpu"
+    t.integer "ram"
+    t.string "storage"
+    t.boolean "cve_2018_17144", default: false, null: false
+    t.date "released"
     t.index ["block_id"], name: "index_nodes_on_block_id"
   end
 


### PR DESCRIPTION
Nodes can now be disabled:
<img width="1018" alt="Schermafbeelding 2019-08-07 om 11 52 22" src="https://user-images.githubusercontent.com/10217/62614462-b8570400-b90b-11e9-8449-c2f5fbd8b435.png">

Disabling a node removes it from the list of nodes on the public facing site. It also stops polling. A node should be disabled _before_ changing the software on the linux machine. The only exception is switching release candidates.

Once a node is added, it's no longer possible to edit the coin or client type, but the release candidate field can still be edited :
<img width="313" alt="Schermafbeelding 2019-08-07 om 11 52 57" src="https://user-images.githubusercontent.com/10217/62614568-fbb17280-b90b-11e9-8d26-dd711ebdf792.png">

You can now add more info about each node (see #36). This info will be displayed in a followup PR.
<img width="334" alt="Schermafbeelding 2019-08-07 om 11 39 22" src="https://user-images.githubusercontent.com/10217/62615186-1f28ed00-b90d-11e9-9d51-06383cabb3e9.png">

