### PR TITLE
Nodes table and behind icon

### DIFF
--- a/app/javascript/packs/forkMonitorApp/components/chaintip.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/chaintip.jsx
@@ -8,7 +8,8 @@ import {
     Row,
     Col,
     BreadcrumbItem,
-    Breadcrumb
+    Breadcrumb,
+    Table
 } from 'reactstrap';
 
 import Node from './node';
@@ -32,14 +33,17 @@ class Chaintip extends React.Component {
             <br />
             Latest block transaction count: <NumberFormat value={ this.props.chaintip.block.tx_count } displayType={'text'} thousandSeparator={true} />
           </p>
-          Nodes:
-          <ul>
-          {this.props.chaintip.nodes.map(function (node, index) {
-            return (
-              <Node node={ node } key={node.id} chaintip={ this.props.chaintip } className="pull-left node-info" />
-            )
-          }.bind(this))}
-          </ul>
+          <small>
+            <Table striped>
+              <tbody>
+                {this.props.chaintip.nodes.map(function (node, index) {
+                  return (
+                    <Node node={ node } key={node.id} chaintip={ this.props.chaintip } className="pull-left node-info" />
+                  )
+                }.bind(this))}
+              </tbody>
+            </Table>
+          </small>
           {  this.props.last &&
             <hr/>
           }

--- a/app/javascript/packs/forkMonitorApp/components/node.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/node.jsx
@@ -9,6 +9,7 @@ import {
 } from 'reactstrap';
 
 import NodeName from './nodeName';
+import NodeInfo from './nodeInfo';
 import NodeBehind from './nodeBehind';
 
 class Node extends React.Component {
@@ -25,6 +26,7 @@ class Node extends React.Component {
       <li>
         <b>
           <NodeName node={this.props.node} />
+          <NodeInfo node={this.props.node} />
           <span> {badge}</span>
         </b>
         <NodeBehind chaintip={ this.props.chaintip } node={ this.props.node }/>

--- a/app/javascript/packs/forkMonitorApp/components/node.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/node.jsx
@@ -11,6 +11,7 @@ import {
 import NodeName from './nodeName';
 import NodeInfo from './nodeInfo';
 import NodeBehind from './nodeBehind';
+import NodeBehindBlocks from './nodeBehindBlocks';
 
 class Node extends React.Component {
   render() {
@@ -25,10 +26,11 @@ class Node extends React.Component {
     return(
       <tr>
         <td>
+          <NodeBehindBlocks chaintip={ this.props.chaintip } node={ this.props.node }/>
           <NodeName node={this.props.node} />
-          <NodeInfo node={this.props.node} />
+          <NodeInfo chaintip={ this.props.chaintip } node={this.props.node} />
           <span> {badge}</span>
-          <NodeBehind chaintip={ this.props.chaintip } node={ this.props.node }/>
+          <NodeBehind chaintip={ this.props.chaintip } node={ this.props.node } min={ 2 } />
         </td>
       </tr>
     )

--- a/app/javascript/packs/forkMonitorApp/components/node.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/node.jsx
@@ -23,14 +23,14 @@ class Node extends React.Component {
       badge = <Badge color="success">Online</Badge>;
     }
     return(
-      <li>
-        <b>
+      <tr>
+        <td>
           <NodeName node={this.props.node} />
           <NodeInfo node={this.props.node} />
           <span> {badge}</span>
-        </b>
-        <NodeBehind chaintip={ this.props.chaintip } node={ this.props.node }/>
-      </li>
+          <NodeBehind chaintip={ this.props.chaintip } node={ this.props.node }/>
+        </td>
+      </tr>
     )
   }
 }

--- a/app/javascript/packs/forkMonitorApp/components/nodeBehind.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/nodeBehind.jsx
@@ -1,20 +1,25 @@
 import React from 'react';
 
+import { Badge } from 'reactstrap';
+
 class NodeBehind extends React.Component {
   render() {
     let chaintipHeight = this.props.chaintip ? this.props.chaintip.block.height : null;
     let nodeHeight = this.props.node ? this.props.node.height : null;
     let delta = chaintipHeight && nodeHeight && chaintipHeight - nodeHeight;
 
-    if (delta <= 0) {
+    if (delta < this.props.min) {
       return(<span />)
     }
 
     return(
-      <span> (
-      { delta }
-      { delta == 1 ? " block " : " blocks " }
-      behind)
+      <span> <Badge color={ delta <= 1 ? "info" : delta <= 5 ? "warning" : "danger" }>
+          { delta + " " }
+          { this.props.verbose &&
+            <span>{ delta == 1 ? "block " : "blocks " }</span>
+          }
+          behind
+        </Badge>
       </span>
     )
   }

--- a/app/javascript/packs/forkMonitorApp/components/nodeBehindBlocks.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/nodeBehindBlocks.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+class NodeBehindBlocks extends React.Component {
+  render() {
+    let chaintipHeight = this.props.chaintip ? this.props.chaintip.block.height : null;
+    let nodeHeight = this.props.node ? this.props.node.height : null;
+    let delta = chaintipHeight && nodeHeight && chaintipHeight - nodeHeight;
+
+    if (delta <= 0) {
+      return(<span />)
+    }
+
+    if (delta <= 4) {
+      let blocks = [...Array(delta)].map((e) => "←◼️");
+      return(<span>{ blocks }</span>)
+    }
+
+    return(<span>←◼️…←◼️</span>)
+  }
+}
+export default NodeBehindBlocks

--- a/app/javascript/packs/forkMonitorApp/components/nodeInfo.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/nodeInfo.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { Tooltip } from 'reactstrap';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
+
+class NodeInfo extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.toggle = this.toggle.bind(this);
+    this.state = {
+      tooltipOpen: false
+    };
+  }
+
+  toggle() {
+    this.setState({
+      tooltipOpen: !this.state.tooltipOpen
+    });
+  }
+
+  render() {
+    return(
+      <span>
+      <span> <FontAwesomeIcon icon={faInfoCircle} href="#" id={`node-${ this.props.node.id }-info`} /></span>
+        <Tooltip
+          placement="auto"
+          isOpen={this.state.tooltipOpen}
+          target={`node-${ this.props.node.id }-info`}
+          toggle={this.toggle}
+          boundariesElement="window"
+          modifiers={{preventOverflow: { enabled: false } }, {hide: { enabled: false } } }
+          style={{maxWidth: "100%"}}
+        >
+          <ul style={{textAlign: "left", paddingLeft: 0, marginBottom: 0}}>
+            <li>Operating system: { this.props.node.os }</li>
+            <li>CPU: { this.props.node.cpu }</li>
+            <li>RAM: { this.props.node.ram } GB</li>
+            <li>Storage: { this.props.node.storage }</li>
+            <li>Pruned: { this.props.node.pruned ? "Yes" : "No" }</li>
+            <li>CVE-2018-17144 Inflation Exposure: { this.props.node.cve_2018_17144 ? "Yes" : "No" }</li>
+            <li>Client release date: { this.props.node.released }</li>
+          </ul>
+        </Tooltip>
+      </span>
+    )
+  }
+}
+export default NodeInfo

--- a/app/javascript/packs/forkMonitorApp/components/nodeInfo.jsx
+++ b/app/javascript/packs/forkMonitorApp/components/nodeInfo.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import NodeBehind from './nodeBehind';
+
 import { Tooltip } from 'reactstrap';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -32,9 +34,10 @@ class NodeInfo extends React.Component {
           toggle={this.toggle}
           boundariesElement="window"
           modifiers={{preventOverflow: { enabled: false } }, {hide: { enabled: false } } }
-          style={{maxWidth: "100%"}}
+          style={{maxWidth: "100%", textAlign: "left"}}
         >
-          <ul style={{textAlign: "left", paddingLeft: 0, marginBottom: 0}}>
+          <NodeBehind chaintip={ this.props.chaintip } node={ this.props.node } min={ 1 } verbose={ true } />
+          <ul style={{paddingLeft: 0, marginBottom: 0}}>
             <li>Operating system: { this.props.node.os }</li>
             <li>CPU: { this.props.node.cpu }</li>
             <li>RAM: { this.props.node.ram } GB</li>


### PR DESCRIPTION
Fixes #32 
Depends on #65 

Nodes are displayed in a table and with slightly smaller font.
<img width="439" alt="Schermafbeelding 2019-08-07 om 15 07 38" src="https://user-images.githubusercontent.com/10217/62625246-1d6b2380-b925-11e9-8fc5-b9571ef57990.png">


The number of blocks a node is behind is indicated with ←◼️. If it's more than 4 blocks an ellipsis is used and a text specifies the number. The tooltip also includes the number of blocks behind if any.

<img width="443" alt="Schermafbeelding 2019-08-07 om 15 08 13" src="https://user-images.githubusercontent.com/10217/62625289-3247b700-b925-11e9-936e-7ab69924b2db.png">

