### PR TITLE
Fix chaintip split display

### DIFF
--- a/app/models/chaintip.rb
+++ b/app/models/chaintip.rb
@@ -1,7 +1,8 @@
 class Chaintip < ApplicationRecord
   belongs_to :block, optional: false
   belongs_to :node, optional: false
-  belongs_to :parent_chaintip, class_name: 'Chaintip', foreign_key: 'parent_chaintip_id', optional: true  # When a node is behind, we assume it would agree with this chaintip, until getchaintips says otherwise
+  belongs_to :parent_chaintip, class_name: 'Chaintip', foreign_key: 'parent_chaintip_id', optional: true, :dependent => :destroy  # When a node is behind, we assume it would agree with this chaintip, until getchaintips says otherwise
+  has_many :children,  class_name: 'Chaintip', foreign_key: 'parent_chaintip_id', :dependent => :nullify
 
   enum coin: [:btc, :bch, :bsv]
 

--- a/app/models/chaintip.rb
+++ b/app/models/chaintip.rb
@@ -11,8 +11,10 @@ class Chaintip < ApplicationRecord
   def nodes
     return nil if status != "active"
     res = Node.where("block_id = ?", self.block_id).order(client_type: :asc ,name: :asc, version: :desc).to_a
-    Chaintip.where(status: self.status, parent_chaintip: self).each do |child|
-      res.append child.node
+    self.children.each do |child|
+      Node.where("block_id = ?", child.block_id).order(client_type: :asc ,name: :asc, version: :desc).each do |node_for_child|
+        res.append node_for_child
+      end
     end
     res
   end

--- a/app/models/chaintip.rb
+++ b/app/models/chaintip.rb
@@ -10,7 +10,7 @@ class Chaintip < ApplicationRecord
 
   def nodes
     return nil if status != "active"
-    res = Node.joins(:chaintips).where("chaintips.block_id = ?", self.block_id).where("chaintips.status = ?", self.status).order(client_type: :asc ,name: :asc, version: :desc).to_a
+    res = Node.where("block_id = ?", self.block_id).order(client_type: :asc ,name: :asc, version: :desc).to_a
     Chaintip.where(status: self.status, parent_chaintip: self).each do |child|
       res.append child.node
     end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -150,7 +150,7 @@ class Node < ApplicationRecord
 
         tip = Chaintip.find_or_create_by(coin: :btc, node: self, status: "active")
         tip.update block: self.block, parent_chaintip: nil
-        tip.match_parent!(self.block, self)
+        tip.match_parent!(self)
         return nil
       end
     end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -136,11 +136,11 @@ class Node < ApplicationRecord
   # 2. the node has a consensus bug
   def check_chaintips!
     if self.unreachable_since || self.ibd || self.block.nil?
-      # Remove cached chaintips from db and return nil if node is unreachble or in IBD:
+      # Remove cached chaintips from db and return nil if node is unreachbale or in IBD:
       Chaintip.where(node: self).destroy_all
       return nil
     else
-      # Delete existing chaintip entries, except the active one (which is unique):
+      # Delete existing chaintip entries, except the active one (which might be unchanged):
       Chaintip.where(node: self).where.not(status: "active").destroy_all
 
       # libbitcoin, btcd and older Bitcoin Core versions don't implement getchaintips, so we mock it:

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -148,9 +148,7 @@ class Node < ApplicationRecord
          self.client_type.to_sym == :btcd ||
          (self.client_type.to_sym == :core && self.version.present? && self.version < 100000)
 
-        tip = Chaintip.find_or_create_by(coin: :btc, node: self, status: "active")
-        tip.update block: self.block, parent_chaintip: nil
-        tip.match_parent!(self)
+        Chaintip.process_active!(self, block)
         return nil
       end
     end

--- a/spec/factories/chaintips.rb
+++ b/spec/factories/chaintips.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+   factory :chaintip do
+     coin { :btc }
+     node
+     block
+     status { :active }
+   end
+ end

--- a/spec/models/chaintip_spec.rb
+++ b/spec/models/chaintip_spec.rb
@@ -1,5 +1,46 @@
 require 'rails_helper'
 
 RSpec.describe Chaintip, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "match_parent!" do
+    let(:nodeA) { create(:node) }
+    let(:nodeB) { create(:node) }
+    let(:block1) { create(:block) }
+    let(:block2) { create(:block, parent: block1) }
+    let(:block3) { create(:block, parent: block2) }
+    let(:chaintip1) { create(:chaintip, block: block1, node: nodeA) }
+    let(:chaintip2) { create(:chaintip, block: block1, node: nodeB) }
+
+    it "should do nothing if all nodes are the same height" do
+      chaintip2.match_parent!(nodeB)
+      assert_nil chaintip2.parent_chaintip
+    end
+
+    describe "when another chaintip is longer" do
+      before do
+        chaintip1.update block: block2
+      end
+
+      it "should mark longer chain as parent" do
+        chaintip2.match_parent!(nodeB)
+        assert_equal(chaintip2.parent_chaintip, chaintip1)
+      end
+
+
+      it "should mark even longer chain as parent" do
+        chaintip1.update block: block3
+        chaintip2.match_parent!(nodeB)
+        assert_equal(chaintip2.parent_chaintip, chaintip1)
+      end
+
+      it "should not mark invalid chain as parent" do
+        # Node B considers block b invalid:
+        chaintip3 = create(:chaintip, block: block2, node: nodeB, status: "invalid")
+
+        chaintip2.match_parent!(nodeB)
+        assert_equal(chaintip2.parent_chaintip, nil)
+      end
+
+    end
+
+  end
 end

--- a/spec/models/chaintip_spec.rb
+++ b/spec/models/chaintip_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Chaintip, type: :model do
   describe "process_active!" do
-    let(:nodeA) { create(:node) }
-    let(:nodeB) { create(:node) }
     let(:block1) { create(:block) }
     let(:block2) { create(:block, parent: block1) }
     let(:block3) { create(:block, parent: block2) }
+    let(:nodeA) { create(:node) }
+    let(:nodeB) { create(:node) }
     let(:chaintip1) { create(:chaintip, block: block2, node: nodeA) }
 
     it "should reuse chaintip for the same block" do
@@ -33,10 +33,10 @@ RSpec.describe Chaintip, type: :model do
   end
 
   describe "nodes / process_active!" do
-    let(:nodeA) { create(:node) }
-    let(:nodeB) { create(:node) }
     let(:block1) { create(:block) }
     let(:block2) { create(:block, parent: block1) }
+    let(:nodeA) { create(:node, block: block1) }
+    let(:nodeB) { create(:node) }
     let(:chaintip1) { create(:chaintip, block: block1, node: nodeA) }
 
     it "should only support the active chaintip" do
@@ -49,13 +49,16 @@ RSpec.describe Chaintip, type: :model do
     end
 
     it "should show all nodes at height of active chaintip" do
+      nodeB.update block: block1
       Chaintip.process_active!(nodeB, block1)
       assert_equal 2, chaintip1.nodes.count
-      assert_equal [nodeB, nodeA], chaintip1.nodes
+      assert_equal [nodeA, nodeB], chaintip1.nodes
     end
 
     it "should include parent blocks in chaintip" do
       chaintip1.update block: block2
+      nodeA.update block: block2
+      nodeB.update block: block1
       Chaintip.process_active!(nodeB, block1)
       assert_equal 2, chaintip1.nodes.count
       assert_equal [nodeA, nodeB], chaintip1.nodes

--- a/spec/models/chaintip_spec.rb
+++ b/spec/models/chaintip_spec.rb
@@ -1,6 +1,68 @@
 require 'rails_helper'
 
 RSpec.describe Chaintip, type: :model do
+  describe "process_active!" do
+    let(:nodeA) { create(:node) }
+    let(:nodeB) { create(:node) }
+    let(:block1) { create(:block) }
+    let(:block2) { create(:block, parent: block1) }
+    let(:block3) { create(:block, parent: block2) }
+    let(:chaintip1) { create(:chaintip, block: block2, node: nodeA) }
+
+    it "should reuse chaintip for the same block" do
+      chaintip1 # ensure it's instantiated before the next line
+      tip = Chaintip.process_active!(nodeB, block2)
+      expect(tip).to eq(chaintip1)
+    end
+
+    it "should match parent block" do
+      chaintip1
+      tip = Chaintip.process_active!(nodeB, block1)
+      expect(tip).not_to be(chaintip1)
+      expect(tip.parent_chaintip).to eq(chaintip1)
+    end
+
+    it "should match child block" do
+      chaintip1
+      # Feed node B a chaintip that's more recent than the chaintip for node A
+      tip = Chaintip.process_active!(nodeB, block3)
+      expect(tip).not_to be(chaintip1)
+      chaintip1.reload
+      expect(chaintip1.parent_chaintip).to eq(tip)
+    end
+  end
+
+  describe "nodes / process_active!" do
+    let(:nodeA) { create(:node) }
+    let(:nodeB) { create(:node) }
+    let(:block1) { create(:block) }
+    let(:block2) { create(:block, parent: block1) }
+    let(:chaintip1) { create(:chaintip, block: block1, node: nodeA) }
+
+    it "should only support the active chaintip" do
+      chaintip1.update status: "invalid"
+      assert_nil chaintip1.nodes
+    end
+
+    it "should the original node for this active chaintip" do
+      assert_equal chaintip1.nodes, [nodeA]
+    end
+
+    it "should show all nodes at height of active chaintip" do
+      Chaintip.process_active!(nodeB, block1)
+      assert_equal 2, chaintip1.nodes.count
+      assert_equal [nodeB, nodeA], chaintip1.nodes
+    end
+
+    it "should include parent blocks in chaintip" do
+      chaintip1.update block: block2
+      Chaintip.process_active!(nodeB, block1)
+      assert_equal 2, chaintip1.nodes.count
+      assert_equal [nodeA, nodeB], chaintip1.nodes
+    end
+
+  end
+
   describe "match_parent!" do
     let(:nodeA) { create(:node) }
     let(:nodeB) { create(:node) }


### PR DESCRIPTION
Sometimes we show two chaintips even though there should only be one: 

![767254b2d1c67519fec257429b606c44eca9b3f1ccd572952989e654103deee6](https://user-images.githubusercontent.com/10217/62715357-a2773b00-ba00-11e9-8f70-2956c82927e5.png)

I suspect this happens during a poll when new nodes are updated but older nodes not yet.

An additional potential mitigation is in b4399af033df65a66a2be7676b102f6f2366d00d and c6ab9092f396686c147b3e179caf91ac8d19337f, which prevents the `rake poll` 10 minutely cron from getting in the way of the `rake poll_repeat` continuous process. We use `rake nodes:poll_unless_fresh` instead now.