### PR TITLE
Add size and time to stale block notifications 

### DIFF
--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -75,13 +75,15 @@ class Block < ApplicationRecord
     end
   end
 
-  def summary
+  def summary(time=false)
     result = block_hash + " ("
     if size.present?
       result += "#{ (size / 1000.0 / 1000.0).round(2) } MB, "
     end
-
-    return result + "#{ pool.present? ? pool : "Unknown pool" })"
+    if time
+      result += "#{ Time.at(timestamp).utc.strftime("%H:%M:%S") } by "
+    end
+    return result + "#{ pool.present? ? pool : "unknown pool" })"
   end
 
   def self.create_with(block_info, node)

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -75,6 +75,10 @@ class Block < ApplicationRecord
     end
   end
 
+  def summary
+    return block_hash + " (#{ pool.present? ? pool : "Unknown pool" })"
+  end
+
   def self.create_with(block_info, node)
     # Set pool:
     pool = node.get_pool_for_block!(block_info["hash"], block_info)

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -76,7 +76,12 @@ class Block < ApplicationRecord
   end
 
   def summary
-    return block_hash + " (#{ pool.present? ? pool : "Unknown pool" })"
+    result = block_hash + " ("
+    if size.present?
+      result += "#{ (size / 1000.0 / 1000.0).round(2) } MB, "
+    end
+
+    return result + "#{ pool.present? ? pool : "Unknown pool" })"
   end
 
   def self.create_with(block_info, node)

--- a/app/views/feeds/invalid_blocks.rss.builder
+++ b/app/views/feeds/invalid_blocks.rss.builder
@@ -9,7 +9,7 @@ xml.rss :version => "2.0" do
     @invalid_blocks.each do |invalid_block|
       xml.item do
         xml.title "Block #{ invalid_block.block.height } marked invalid by #{ invalid_block.node.name_with_version }"
-        xml.description "Block #{ invalid_block.block.height } (#{ invalid_block.block.pool.present? ? invalid_block.block.pool : "Unknown pool" }) marked invalid by #{ invalid_block.node.name_with_version }. This block was first seen and accepted as valid by #{ invalid_block.block.first_seen_by.name_with_version }."
+        xml.description "Block #{ invalid_block.block.height } (#{ invalid_block.block.summary }) marked invalid by #{ invalid_block.node.name_with_version }. This block was first seen and accepted as valid by #{ invalid_block.block.first_seen_by.name_with_version }."
         xml.pubDate invalid_block.created_at.to_s(:rfc822)
         xml.link api_v1_invalid_block_url(invalid_block)
         xml.guid api_v1_invalid_block_url(invalid_block)

--- a/app/views/feeds/stale_candidates.rss.builder
+++ b/app/views/feeds/stale_candidates.rss.builder
@@ -9,7 +9,7 @@ xml.rss :version => "2.0" do
     @stale_candidates.each do |stale_candidate|
       xml.item do
         xml.title "There are #{ Block.where(coin: stale_candidate.coin, height: stale_candidate.height).count } distinct blocks at height #{ stale_candidate.height }"
-        xml.description "Blocks: #{ Block.where(coin: stale_candidate.coin, height: stale_candidate.height).collect {|block| block.block_hash + " (#{ block.pool.present? ? block.pool : "Unknown pool" })" }.join(', ')}"
+        xml.description "Blocks: #{ Block.where(coin: stale_candidate.coin, height: stale_candidate.height).collect {|block| block.summary }.join(', ')}"
         xml.pubDate stale_candidate.created_at.to_s(:rfc822)
         xml.link api_v1_stale_candidate_url(stale_candidate)
         xml.guid api_v1_stale_candidate_url(stale_candidate)

--- a/app/views/feeds/stale_candidates.rss.builder
+++ b/app/views/feeds/stale_candidates.rss.builder
@@ -9,7 +9,7 @@ xml.rss :version => "2.0" do
     @stale_candidates.each do |stale_candidate|
       xml.item do
         xml.title "There are #{ Block.where(coin: stale_candidate.coin, height: stale_candidate.height).count } distinct blocks at height #{ stale_candidate.height }"
-        xml.description "Blocks: #{ Block.where(coin: stale_candidate.coin, height: stale_candidate.height).collect {|block| block.summary }.join(', ')}"
+        xml.description "Blocks: #{ Block.where(coin: stale_candidate.coin, height: stale_candidate.height).collect {|block| block.summary(time = true) }.join(', ')}"
         xml.pubDate stale_candidate.created_at.to_s(:rfc822)
         xml.link api_v1_stale_candidate_url(stale_candidate)
         xml.guid api_v1_stale_candidate_url(stale_candidate)

--- a/app/views/user_mailer/stale_candidate_email.html.erb
+++ b/app/views/user_mailer/stale_candidate_email.html.erb
@@ -3,7 +3,7 @@
   <ul>
     <% @blocks.each do | block | %>
       <li>
-        <%= block.summary %>
+        <%= block.summary(time = true) %>
       </li>
     <% end %>
   </ul>

--- a/app/views/user_mailer/stale_candidate_email.html.erb
+++ b/app/views/user_mailer/stale_candidate_email.html.erb
@@ -3,12 +3,7 @@
   <ul>
     <% @blocks.each do | block | %>
       <li>
-        <%= block.block_hash %>
-        <% if block.pool.present? %>
-          (<%= block.pool %>)
-        <% else %>
-          (unknown pool)
-        <% end %>
+        <%= block.summary %>
       </li>
     <% end %>
   </ul>

--- a/app/views/user_mailer/stale_candidate_email.text.erb
+++ b/app/views/user_mailer/stale_candidate_email.text.erb
@@ -1,12 +1,7 @@
 We found <%= @blocks.count %> blocks at height <%= @stale_candidate.height %>:
 
 <% @blocks.each do | block | %>
-  * <%= block.block_hash %>
-  <% if block.pool.present? %>
-    (<%= block.pool %>)
-  <% else %>
-    (unknown pool)
-  <% end %>
+  * <%= block.summary %>
 <% end %>
 
 For more information, see: <%= nodes_for_coin_url(@stale_candidate.coin.downcase) %>

--- a/app/views/user_mailer/stale_candidate_email.text.erb
+++ b/app/views/user_mailer/stale_candidate_email.text.erb
@@ -1,7 +1,7 @@
 We found <%= @blocks.count %> blocks at height <%= @stale_candidate.height %>:
 
 <% @blocks.each do | block | %>
-  * <%= block.summary %>
+  * <%= block.summary(time = true) %>
 <% end %>
 
 For more information, see: <%= nodes_for_coin_url(@stale_candidate.coin.downcase) %>

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Block, :type => :model do
     end
     it "should show 'unknown pool'" do
       block = create(:block, pool: nil)
-      expect(block.summary).to include("Unknown pool")
+      expect(block.summary).to include("unknown pool")
     end
     it "should include the block size in MB" do
       block = create(:block, pool: "Antpool", size: 300000)
@@ -27,11 +27,18 @@ RSpec.describe Block, :type => :model do
       block = create(:block, pool: "Antpool", size: 289999)
       expect(block.summary).to include("0.29 MB")
     end
+    it "should show time of day if requested" do
+      block = create(:block, pool: nil, size: nil, timestamp: 1566575008)
+      expect(block.summary(time: true)).to include("(15:43:28")
+    end
     it "should use interpunction" do
-      block = create(:block, block_hash: "0000000", pool: "Antpool", size: 289999)
-      expect(block.summary).to eq("0000000 (0.29 MB, Antpool)")
+      block = create(:block, block_hash: "0000000", pool: "Antpool", size: 289999, timestamp: 1566575008)
+      expect(block.summary()).to eq("0000000 (0.29 MB, Antpool)")
+      expect(block.summary(time: true)).to eq("0000000 (0.29 MB, 15:43:28 by Antpool)")
+      block.pool = nil
+      expect(block.summary(time: true)).to eq("0000000 (0.29 MB, 15:43:28 by unknown pool)")
       block.size = nil
-      expect(block.summary).to eq("0000000 (Antpool)")
+      expect(block.summary).to eq("0000000 (unknown pool)")
     end
   end
 

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -10,6 +10,31 @@ RSpec.describe Block, :type => :model do
     end
   end
 
+  describe "summary" do
+    it "should show the pool" do
+      block = create(:block, pool: "Antpool")
+      expect(block.summary).to include("Antpool")
+    end
+    it "should show 'unknown pool'" do
+      block = create(:block, pool: nil)
+      expect(block.summary).to include("Unknown pool")
+    end
+    it "should include the block size in MB" do
+      block = create(:block, pool: "Antpool", size: 300000)
+      expect(block.summary).to include("0.3 MB")
+    end
+    it "should round the block size to two decimals" do
+      block = create(:block, pool: "Antpool", size: 289999)
+      expect(block.summary).to include("0.29 MB")
+    end
+    it "should use interpunction" do
+      block = create(:block, block_hash: "0000000", pool: "Antpool", size: 289999)
+      expect(block.summary).to eq("0000000 (0.29 MB, Antpool)")
+      block.size = nil
+      expect(block.summary).to eq("0000000 (Antpool)")
+    end
+  end
+
   describe "version_bits" do
     it "should be empty by default" do
       block = create(:block)


### PR DESCRIPTION
Stale blocks and reorgs on BCH/BSV often appear related to block size, so we include that information in the stale block RSS feed and email notifications. When blocks are produced almost at the same time then their staleness is likely not a result of block size, so we include that information as well. 

See e.g. after deploy: https://forkmonitor.info/feeds/stale_candidates/btc.rss