### PR TITLE
Check inflation for all mirror nodes  

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ before_script:
 script:
   - bundle exec rake
   - npm test
-  - npm run coveralls
+  - npm run coveralls || echo "push to coveralls failed"

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -51,7 +51,7 @@ class UserMailer < ApplicationMailer
 
     mail(
       to: @user.email,
-      subject: "[ForkMonitor] too much inflation in #{ @inflated_block.block.coin.upcase } block #{ @inflated_block.block.height } (#{ @inflated_block.block.block_hash })"
+      subject: "[ForkMonitor] #{ @inflated_block.node.name_with_version } detected too much inflation in #{ @inflated_block.block.coin.upcase } block #{ @inflated_block.block.height } (#{ @inflated_block.block.block_hash })"
     )
   end
 

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -155,8 +155,8 @@ class Block < ApplicationRecord
 
   def self.check_inflation!
     Node.all.each do |node|
-      next unless node.mirror_node? && node.coin == "BTC" && node.core?
-      puts "Check inflation for #{ node.name_with_version }..." unless Rails.env.test?
+      next unless node.mirror_node? && node.core?
+      puts "Check #{ node.coin } inflation for #{ node.name_with_version }..." unless Rails.env.test?
       throw "Node in Initial Blockchain Download" if node.ibd
 
       # Avoid expensive call if we already have this information for the most recent tip (of the mirror node):

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -4,6 +4,7 @@ class Node < ApplicationRecord
   has_many :blocks_first_seen, class_name: "Block", foreign_key: "first_seen_by_id", dependent: :nullify
   has_many :invalid_blocks
   has_many :inflated_blocks
+  has_many :tx_outsets
   belongs_to :mirror_block, required: false, class_name: "Block"
 
   default_scope { where(enabled: true) }

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -129,13 +129,12 @@ class Node < ApplicationRecord
 
     block = self.ibd ? nil : Block.find_or_create_block_and_ancestors!(best_block_hash, self)
 
-    self.update block: block, unreachable_since: nil
-    
-    # Get most recent block height from mirror node
-    poll_mirror! if mirror_node?
+    self.update block: block, unreachable_since: nil    
   end
   
+  # Get most recent block height from mirror node
   def poll_mirror!
+    return unless mirror_node?
     return unless self.core?
     puts "Polling mirror node..." unless Rails.env.test?
     begin

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -117,8 +117,6 @@ class Node < ApplicationRecord
     block = self.ibd ? nil : Block.find_or_create_block_and_ancestors!(best_block_hash, self)
 
     self.update block: block, unreachable_since: nil
-
-    return if block.nil?
   end
 
   # getchaintips returns all known chaintips for a node, which can be:

--- a/app/models/tx_outset.rb
+++ b/app/models/tx_outset.rb
@@ -1,3 +1,4 @@
 class TxOutset < ApplicationRecord
   belongs_to :block
+  belongs_to :node
 end

--- a/app/views/feeds/inflated_blocks.rss.builder
+++ b/app/views/feeds/inflated_blocks.rss.builder
@@ -9,7 +9,7 @@ xml.rss :version => "2.0" do
     @inflated_blocks.each do |inflated_block|
       xml.item do
         xml.title "#{ inflated_block.actual_inflation -  inflated_block.max_inflation } BTC extra inflation between height #{ inflated_block.comparison_block.height } and #{ inflated_block.block.height }."
-        xml.description "Unexpected #{ inflated_block.actual_inflation -  inflated_block.max_inflation } BTC extra inflation between height #{ inflated_block.comparison_block.height } and #{ inflated_block.block.height }. This block was first seen and accepted as valid by #{ inflated_block.block.first_seen_by.name_with_version }."
+        xml.description "Unexpected #{ inflated_block.actual_inflation -  inflated_block.max_inflation } BTC extra inflation between height #{ inflated_block.comparison_block.height } and #{ inflated_block.block.height }."
         xml.pubDate inflated_block.created_at.to_s(:rfc822)
         xml.link api_v1_inflated_block_url(inflated_block)
         xml.guid api_v1_inflated_block_url(inflated_block)

--- a/app/views/user_mailer/inflated_block_email.html.erb
+++ b/app/views/user_mailer/inflated_block_email.html.erb
@@ -1,13 +1,10 @@
 <p>
-  Unexpected <%=  @inflated_block.actual_inflation -  @inflated_block.max_inflation %> BTC extra inflation
+  <%= @inflated_block.node.name_with_version %> detected an unexpected <%=  @inflated_block.actual_inflation -  @inflated_block.max_inflation %> BTC extra inflation
   between block height <%=  @inflated_block.comparison_block.height %> and <%= @inflated_block.block.height %>
 </p>
-<% if @inflated_block.block.first_seen_by.present? %>
 <p>
-  This block was first seen and accepted as valid by <%= @inflated_block.block.first_seen_by.name_with_version %>.
   It was mined by <%= @inflated_block.block.pool ? @inflated_block.block.pool : "an unknown pool" %>.
 </p>
-<% end %>
 
 <p>
   For more information, see: <%= nodes_for_coin_url(@inflated_block.block.coin.downcase) %>

--- a/db/migrate/20190927102026_add_node_to_txoutsets.rb
+++ b/db/migrate/20190927102026_add_node_to_txoutsets.rb
@@ -1,0 +1,7 @@
+class AddNodeToTxoutsets < ActiveRecord::Migration[5.2]
+  def up
+    add_reference :tx_outsets, :node, foreign_key: true
+    node = Node.bitcoin_core_by_version.first
+    TxOutset.update_all node_id: node.id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_27_073647) do
+ActiveRecord::Schema.define(version: 2019_09_27_102026) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,7 +142,9 @@ ActiveRecord::Schema.define(version: 2019_09_27_073647) do
     t.decimal "total_amount", precision: 16, scale: 8
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "node_id"
     t.index ["block_id"], name: "index_tx_outsets_on_block_id"
+    t.index ["node_id"], name: "index_tx_outsets_on_node_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -182,6 +184,7 @@ ActiveRecord::Schema.define(version: 2019_09_27_073647) do
   add_foreign_key "invalid_blocks", "nodes"
   add_foreign_key "nodes", "blocks"
   add_foreign_key "tx_outsets", "blocks"
+  add_foreign_key "tx_outsets", "nodes"
   add_foreign_key "version_bits", "blocks", column: "activate_block_id"
   add_foreign_key "version_bits", "blocks", column: "deactivate_block_id"
 end

--- a/spec/factories/nodes.rb
+++ b/spec/factories/nodes.rb
@@ -8,4 +8,9 @@ FactoryBot.define do
    factory :node_with_block, parent: :node do
      block
    end
+   
+   factory :node_with_mirror, parent: :node do
+     mirror_rpchost { "127.0.0.1" }
+     mirror_rpcport { 8336 }
+   end
  end

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -160,8 +160,12 @@ RSpec.describe Block, :type => :model do
       @node.mirror_client.mock_set_height(560176)
       @node.poll!
       @node.reload
+      
+      @node_without_mirror = build(:node, version: 180000)
+      @node_testnet = build(:node, version: 180000, coin: "TBTC")
+      
       expect(Block.maximum(:height)).to eq(560176)
-      allow(Node).to receive(:bitcoin_core_by_version).and_return [@node]
+      allow(Node).to receive(:all).and_return [@node_without_mirror, @node, @node_testnet]
     end
 
     it "should call gettxoutsetinfo on mirror node" do

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -58,6 +58,52 @@ RSpec.describe Block, :type => :model do
     end
   end
 
+  describe "maximum_inflation" do
+    COIN = 100000000
+
+    it "should be 12.5 for BTC in mid 2019" do
+      @block = build(:block, height: 596808)
+      expect(@block.max_inflation).to eq(12.5 * COIN)
+    end
+    
+    it "should be 50 for BTC in 2009" do
+      @block = build(:block, height: 100)
+      expect(@block.max_inflation).to eq(50 * COIN)
+    end
+    
+    it "should be 12.5 for BTC immediately before the 2020 halving" do
+      @block = build(:block, height: 629999)
+      expect(@block.max_inflation).to eq(12.5 * COIN)
+    end
+    
+    it "should be 6.25 for BTC at the 2020 halving" do
+      @block = build(:block, height: 630000)
+      expect(@block.max_inflation).to eq(6.25 * COIN)
+    end
+    
+    it "should be 0.00000009 for BTC at height 6090000" do
+      @block = build(:block, height: 6090000)
+      expect(@block.max_inflation).to eq(0.00000009 * COIN)
+    end
+    
+    it "should be 0 for BTC as of height 6930000" do
+      @block = build(:block, height: 6930000)
+      expect(@block.max_inflation).to eq(0.00000000 * COIN)
+    end
+    
+    it "should create slightly less than 21 million BTC" do
+       @block = build(:block, height: 0)
+       i=0
+       coins = 0.0
+       while i < 10000000 do
+         @block.height = i
+         coins += 1000 * @block.max_inflation
+         i += 1000
+       end
+       expect(coins).to eq(20999999.9769 * COIN)
+    end
+  end
+
   describe "create_with" do
     before do
       @node = build(:node)

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -188,6 +188,27 @@ RSpec.describe Node, :type => :model do
         expect(@node.unreachable_since).to be_nil
       end
     end
+    
+    describe "mirror node" do
+      before do
+        @node = build(:node_with_mirror)
+
+        @node.client.mock_set_height(560177)
+        @node.mirror_client.mock_set_height(560177)
+        
+        @node.poll! # stores the block and node entry
+      end
+      
+      it "node without mirror node should not have mirror_client" do
+        n = build(:node)
+        expect(n.mirror_client).to be_nil
+      end
+
+      it "should update to the latest mirror node block" do
+        @node.poll!
+        expect(@node.mirror_block.height).to equal(560177)
+      end
+    end
 
     describe "Bitcoin Core 0.13.0" do
       before do


### PR DESCRIPTION
Currently we only check inflation for the most recent Bitcoin Core mainnet node. With this PR we check all Bitcoin Core mainnet and testnet nodes with a mirror node.

Mirror nodes were introduced in a87664275c15e541603664c37401ad948bb3ba7f. They are identical to the main node and are used for slow and blocking RPC calls like `gettxoutsetinfo`. This allows us to continue regular polling of the main nodes while we check for inflation on the mirror nodes.