### PR TITLE
Run tests with real bitcoind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+__pycache__/
 
 # Ignore uploaded files in development
 /storage/*

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ coverage-js
 yarn-debug.log*
 .yarn-integrity
 .env
+
+/vendor/bitcoin-*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/bitcoin"]
+	path = vendor/bitcoin
+	url = https://github.com/bitcoin/bitcoin.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ services:
   - postgresql
 rvm:
   - 2.6.3
+env:
+  - BITCOIN_VERSION=0.19.1rc1 BITCOIND=$TRAVIS_BUILD_DIR/vendor/bitcoin-$BITCOIN_VERSION/bin/bitcoind
 bundler_args: --without production:development
 cache:
   ccache: true
@@ -14,11 +16,14 @@ cache:
   - $HOME/libzmq
 before_install:
   - $TRAVIS_BUILD_DIR/travis-zmq.sh
+  - $TRAVIS_BUILD_DIR/install_bitcoind.sh
   - yarn
 before_script:
   - bundle exec rake db:create RAILS_ENV=test
   - bundle exec rake db:schema:load RAILS_ENV=test
 script:
+  - $BITCOIND --version
+  - bundle exec rake debug:bitcoind
   - bundle exec rake
   - npm test
   - npm run coveralls || echo "push to coveralls failed"

--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,9 @@ group :development, :test do
   gem 'webmock'
 
   gem 'redis-rails'
+
+  # Call Python, e.g. Bitcoin Core test framework
+  gem 'pycall'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,7 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (4.0.1)
     puma (3.12.2)
+    pycall (1.3.0)
     rack (2.0.8)
     rack-cors (1.1.0)
       rack (>= 2.0.0)
@@ -343,6 +344,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg
   puma (~> 3.12.2)
+  pycall
   rack-cors
   rack-timeout
   rails (~> 5.2.3)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Install Postgres, e.g. on macOS: `brew install postgresql`
 
 Install Redis, e.g. on macOS: `brew install redis` and see [instructions](https://medium.com/@petehouston/install-and-config-redis-on-mac-os-x-via-homebrew-eb8df9a4f298).
 
+Install Python. When using pyenv, use `env PYTHON_CONFIGURE_OPTS='--enable-shared' pyenv install VERSION` in order for [PyCall](https://github.com/mrkn/pycall.rb) to work.
+
 Install Ruby 2.6.3 through a version manager such as [RVM](https://rvm.io) or [rbenv](https://github.com/rbenv/rbenv). Install
 the bundler and foreman gems, then run bundler:
 

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -77,7 +77,11 @@ class Node < ApplicationRecord
 
   def client
     if !@client
-      @client = self.class.client_klass.new(self.id, self.name_with_version, self.client_type.to_sym, self.rpchost, self.rpcport, self.rpcuser, self.rpcpassword)
+      if self.python
+        @client = BitcoinClientPython.new(self.id, self.name_with_version, self.client_type.to_sym)
+      else
+        @client = self.class.client_klass.new(self.id, self.name_with_version, self.client_type.to_sym, self.rpchost, self.rpcport, self.rpcuser, self.rpcpassword)
+      end
     end
     return @client
   end

--- a/app/services/bitcoin_client_python.rb
+++ b/app/services/bitcoin_client_python.rb
@@ -1,0 +1,42 @@
+class BitcoinClientPython
+  class Error < StandardError
+  end
+
+  def initialize(node_id, name_with_version, client_type)
+    @client_type = client_type
+    @node_id = node_id
+    @name_with_version = name_with_version
+  end
+
+  def set_python_node(node)
+    @node = node
+  end
+
+  def getblockchaininfo
+    raise Error, "Set Python node" unless @node != nil
+    begin
+      return @node.getblockchaininfo()
+    rescue Error => e
+      raise Error, "getblockchaininfo failed for #{@name_with_version} (id=#{@node_id}): " + e.message
+    end
+  end
+
+  def getinfo
+    raise Error, "Set Python node" unless @node != nil
+    begin
+      return @node.getinfo()
+    rescue Error => e
+      raise Error, "getinfo failed for #{@name_with_version} (id=#{@node_id}): " + e.message
+    end
+  end
+
+  def getnetworkinfo
+    raise Error, "Set Python node" unless @node != nil
+    begin
+      return @node.getnetworkinfo()
+    rescue Error => e
+      raise Error, "getnetworkinfo failed for #{@name_with_version} (id=#{@node_id}): " + e.message
+    end
+  end
+
+end

--- a/db/migrate/20200203143938_add_python_to_nodes.rb
+++ b/db/migrate/20200203143938_add_python_to_nodes.rb
@@ -1,0 +1,5 @@
+class AddPythonToNodes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :nodes, :python, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_28_091141) do
+ActiveRecord::Schema.define(version: 2020_02_03_143938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define(version: 2020_01_28_091141) do
     t.bigint "mirror_block_id"
     t.boolean "txindex", default: false, null: false
     t.datetime "mirror_rest_until"
+    t.boolean "python", default: false, null: false
     t.index ["block_id"], name: "index_nodes_on_block_id"
     t.index ["mirror_block_id"], name: "index_nodes_on_mirror_block_id"
   end

--- a/install_bitcoind.sh
+++ b/install_bitcoind.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cd $TRAVIS_BUILD_DIR/vendor
+# test/config.ini is normally generated at compile time, copy it manually:
+cp bitcoin-config.ini bitcoin/test/config.ini
+wget --quiet https://bitcoincore.org/bin/bitcoin-core-0.19.1/test.rc1/bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz
+tar -xzf bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz bitcoin-$BITCOIN_VERSION

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -1,3 +1,8 @@
+require 'pycall/import'
+include PyCall::Import
+pyimport :sys
+sys.path.insert(0, ".")
+
 namespace 'debug' do :env
   desc "Print basic info from each node"
   task :node_info => :environment do
@@ -15,5 +20,15 @@ namespace 'debug' do :env
       end
       puts ""
     end
+  end
+
+  desc "Spin up and query Bitcoin Core test node"
+  task :bitcoind => :environment do
+    pyfrom :util, import: :TestWrapper
+    test = TestWrapper.new()
+
+    test.setup({loglevel: 'DEBUG'})
+    puts test.nodes[0].getnetworkinfo()
+    test.shutdown()
   end
 end

--- a/spec/factories/nodes.rb
+++ b/spec/factories/nodes.rb
@@ -13,4 +13,8 @@ FactoryBot.define do
      mirror_rpchost { "127.0.0.1" }
      mirror_rpcport { 8336 }
    end
+
+   factory :node_python, parent: :node do
+     python { true }
+   end
  end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -1,14 +1,31 @@
 require "rails_helper"
+require 'pycall/import'
+include PyCall::Import
+pyimport :sys
+sys.path.insert(0, ".")
+pyfrom :util, import: :TestWrapper
 
 RSpec.describe Node, :type => :model do
+  let(:test) { TestWrapper.new() }
+
   before do
     stub_const("BitcoinClient::Error", BitcoinClientMock::Error)
   end
 
   describe "version" do
+    before do
+      test.setup()
+    end
+
+    after do
+      test.shutdown()
+    end
+
     it "should be set" do
-      node = create(:node_with_block, version: 160300)
-      expect(node.version).to eq(160300)
+      node = create(:node_python)
+      node.client.set_python_node(test.nodes[0])
+      node.poll!
+      expect(node.version).to be >=190100
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,6 @@
 require 'coveralls'
 Coveralls.wear!
 
-require 'webmock/rspec'
 
 require 'helpers/controller_spec_helpers.rb'
 

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,3 @@
+require 'webmock/rspec'
+
+WebMock.disable_net_connect!(allow: '127.0.0.1')

--- a/util.py
+++ b/util.py
@@ -21,7 +21,7 @@ class TestWrapper(BitcoinTestFramework):
         pass
 
     def setup(self,
-              bitcoind=os.path.abspath(SOURCE_DIRECTORY + "/src/bitcoind"),
+              bitcoind=None,
               bitcoincli=None,
               setup_clean_chain=True,
               num_nodes=1,

--- a/util.py
+++ b/util.py
@@ -8,97 +8,68 @@ SOURCE_DIRECTORY = os.path.dirname(os.path.abspath(__file__)) + "/vendor/bitcoin
 sys.path.append(SOURCE_DIRECTORY + "/test/functional")
 from test_framework.test_framework import BitcoinTestFramework
 
-class TestWrapper:
-    """Singleton TestWrapper class.
-    This wraps the actual TestWrapper class to ensure that users only ever
-    instantiate a single TestWrapper."""
+class TestWrapper(BitcoinTestFramework):
+    """Wrapper Class for BitcoinTestFramework.
+    Provides the BitcoinTestFramework rpc & daemon process management
+    functionality to external python projects."""
 
-    class __TestWrapper(BitcoinTestFramework):
-        """Wrapper Class for BitcoinTestFramework.
-        Provides the BitcoinTestFramework rpc & daemon process management
-        functionality to external python projects."""
+    def set_test_params(self):
+        # This can be overriden in setup() parameter.
+        self.num_nodes = 1
 
-        def set_test_params(self):
-            # This can be overriden in setup() parameter.
-            self.num_nodes = 1
+    def run_test(self):
+        pass
 
-        def run_test(self):
-            pass
+    def setup(self,
+              bitcoind=os.path.abspath(SOURCE_DIRECTORY + "/src/bitcoind"),
+              bitcoincli=None,
+              setup_clean_chain=True,
+              num_nodes=1,
+              network_thread=None,
+              rpc_timeout=60,
+              supports_cli=False,
+              bind_to_localhost_only=True,
+              nocleanup=False,
+              noshutdown=False,
+              cachedir=os.path.abspath(SOURCE_DIRECTORY + "/test/cache"),
+              tmpdir=None,
+              loglevel='INFO',
+              trace_rpc=False,
+              port_seed=os.getpid(),
+              coveragedir=None,
+              configfile=os.path.abspath(SOURCE_DIRECTORY + "/test/config.ini"),
+              pdbonfailure=False,
+              usecli=False,
+              perf=False,
+              randomseed=None):
 
-        def setup(self,
-                  bitcoind=os.path.abspath(SOURCE_DIRECTORY + "/src/bitcoind"),
-                  bitcoincli=None,
-                  setup_clean_chain=True,
-                  num_nodes=1,
-                  network_thread=None,
-                  rpc_timeout=60,
-                  supports_cli=False,
-                  bind_to_localhost_only=True,
-                  nocleanup=False,
-                  noshutdown=False,
-                  cachedir=os.path.abspath(SOURCE_DIRECTORY + "/test/cache"),
-                  tmpdir=None,
-                  loglevel='INFO',
-                  trace_rpc=False,
-                  port_seed=os.getpid(),
-                  coveragedir=None,
-                  configfile=os.path.abspath(SOURCE_DIRECTORY + "/test/config.ini"),
-                  pdbonfailure=False,
-                  usecli=False,
-                  perf=False,
-                  randomseed=None):
+        self.setup_clean_chain = setup_clean_chain
+        self.num_nodes = num_nodes
+        self.network_thread = network_thread
+        self.rpc_timeout = rpc_timeout
+        self.supports_cli = supports_cli
+        self.bind_to_localhost_only = bind_to_localhost_only
 
-            if self.running:
-                print("TestWrapper is already running!")
-                return
+        self.options = argparse.Namespace
+        self.options.nocleanup = nocleanup
+        self.options.noshutdown = noshutdown
+        self.options.cachedir = cachedir
+        self.options.tmpdir = tmpdir
+        self.options.loglevel = loglevel
+        self.options.trace_rpc = trace_rpc
+        self.options.port_seed = port_seed
+        self.options.coveragedir = coveragedir
+        self.options.configfile = configfile
+        self.options.pdbonfailure = pdbonfailure
+        self.options.usecli = usecli
+        self.options.perf = perf
+        self.options.randomseed = randomseed
+        self.options.valgrind = False
 
-            self.setup_clean_chain = setup_clean_chain
-            self.num_nodes = num_nodes
-            self.network_thread = network_thread
-            self.rpc_timeout = rpc_timeout
-            self.supports_cli = supports_cli
-            self.bind_to_localhost_only = bind_to_localhost_only
+        self.options.bitcoind = bitcoind
+        self.options.bitcoincli = bitcoincli
 
-            self.options = argparse.Namespace
-            self.options.nocleanup = nocleanup
-            self.options.noshutdown = noshutdown
-            self.options.cachedir = cachedir
-            self.options.tmpdir = tmpdir
-            self.options.loglevel = loglevel
-            self.options.trace_rpc = trace_rpc
-            self.options.port_seed = port_seed
-            self.options.coveragedir = coveragedir
-            self.options.configfile = configfile
-            self.options.pdbonfailure = pdbonfailure
-            self.options.usecli = usecli
-            self.options.perf = perf
-            self.options.randomseed = randomseed
-            self.options.valgrind = False
+        super().setup()
 
-            self.options.bitcoind = bitcoind
-            self.options.bitcoincli = bitcoincli
-
-            super().setup()
-
-            self.running = True
-
-        def shutdown(self):
-            if not self.running:
-                print("TestWrapper is not running!")
-            else:
-                super().shutdown()
-                self.running = False
-
-    instance = None
-
-    def __new__(cls):
-        if not TestWrapper.instance:
-            TestWrapper.instance = TestWrapper.__TestWrapper()
-            TestWrapper.instance.running = False
-        return TestWrapper.instance
-
-    def __getattr__(self, name):
-        return getattr(self.instance, name)
-
-    def __setattr__(self, name):
-        return setattr(self.instance, name)
+    def shutdown(self):
+        super().shutdown()

--- a/util.py
+++ b/util.py
@@ -1,0 +1,104 @@
+import argparse
+import os
+import sys
+import importlib.util
+
+SOURCE_DIRECTORY = os.path.dirname(os.path.abspath(__file__)) + "/vendor/bitcoin" or os.environ['BITCOIN_SOURCE']
+
+sys.path.append(SOURCE_DIRECTORY + "/test/functional")
+from test_framework.test_framework import BitcoinTestFramework
+
+class TestWrapper:
+    """Singleton TestWrapper class.
+    This wraps the actual TestWrapper class to ensure that users only ever
+    instantiate a single TestWrapper."""
+
+    class __TestWrapper(BitcoinTestFramework):
+        """Wrapper Class for BitcoinTestFramework.
+        Provides the BitcoinTestFramework rpc & daemon process management
+        functionality to external python projects."""
+
+        def set_test_params(self):
+            # This can be overriden in setup() parameter.
+            self.num_nodes = 1
+
+        def run_test(self):
+            pass
+
+        def setup(self,
+                  bitcoind=os.path.abspath(SOURCE_DIRECTORY + "/src/bitcoind"),
+                  bitcoincli=None,
+                  setup_clean_chain=True,
+                  num_nodes=1,
+                  network_thread=None,
+                  rpc_timeout=60,
+                  supports_cli=False,
+                  bind_to_localhost_only=True,
+                  nocleanup=False,
+                  noshutdown=False,
+                  cachedir=os.path.abspath(SOURCE_DIRECTORY + "/test/cache"),
+                  tmpdir=None,
+                  loglevel='INFO',
+                  trace_rpc=False,
+                  port_seed=os.getpid(),
+                  coveragedir=None,
+                  configfile=os.path.abspath(SOURCE_DIRECTORY + "/test/config.ini"),
+                  pdbonfailure=False,
+                  usecli=False,
+                  perf=False,
+                  randomseed=None):
+
+            if self.running:
+                print("TestWrapper is already running!")
+                return
+
+            self.setup_clean_chain = setup_clean_chain
+            self.num_nodes = num_nodes
+            self.network_thread = network_thread
+            self.rpc_timeout = rpc_timeout
+            self.supports_cli = supports_cli
+            self.bind_to_localhost_only = bind_to_localhost_only
+
+            self.options = argparse.Namespace
+            self.options.nocleanup = nocleanup
+            self.options.noshutdown = noshutdown
+            self.options.cachedir = cachedir
+            self.options.tmpdir = tmpdir
+            self.options.loglevel = loglevel
+            self.options.trace_rpc = trace_rpc
+            self.options.port_seed = port_seed
+            self.options.coveragedir = coveragedir
+            self.options.configfile = configfile
+            self.options.pdbonfailure = pdbonfailure
+            self.options.usecli = usecli
+            self.options.perf = perf
+            self.options.randomseed = randomseed
+            self.options.valgrind = False
+
+            self.options.bitcoind = bitcoind
+            self.options.bitcoincli = bitcoincli
+
+            super().setup()
+
+            self.running = True
+
+        def shutdown(self):
+            if not self.running:
+                print("TestWrapper is not running!")
+            else:
+                super().shutdown()
+                self.running = False
+
+    instance = None
+
+    def __new__(cls):
+        if not TestWrapper.instance:
+            TestWrapper.instance = TestWrapper.__TestWrapper()
+            TestWrapper.instance.running = False
+        return TestWrapper.instance
+
+    def __getattr__(self, name):
+        return getattr(self.instance, name)
+
+    def __setattr__(self, name):
+        return setattr(self.instance, name)

--- a/util.py
+++ b/util.py
@@ -33,7 +33,7 @@ class TestWrapper(BitcoinTestFramework):
               noshutdown=False,
               cachedir=os.path.abspath(SOURCE_DIRECTORY + "/test/cache"),
               tmpdir=None,
-              loglevel='INFO',
+              loglevel='ERROR',
               trace_rpc=False,
               port_seed=os.getpid(),
               coveragedir=None,

--- a/vendor/bitcoin-config.ini
+++ b/vendor/bitcoin-config.ini
@@ -1,0 +1,22 @@
+# Copyright (c) 2013-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# These environment variables are set by the build process and read by
+# test/functional/test_runner.py and test/util/bitcoin-util-test.py
+
+[environment]
+PACKAGE_NAME=Bitcoin Core
+SRCDIR=$TRAVIS_BUILD_DIR/vendor/bitcoin
+BUILDDIR=$TRAVIS_BUILD_DIR/vendor/bitcoin-$BITCOIN_VERSION
+EXEEXT=
+RPCAUTH=$TRAVIS_BUILD_DIR/vendor/bitcoin/bitcoin/share/rpcauth/rpcauth.py
+
+[components]
+# Which components are enabled. These are commented out by `configure` if they were disabled when running config.
+#ENABLE_WALLET=true
+ENABLE_CLI=false
+ENABLE_WALLET_TOOL=false
+ENABLE_BITCOIND=true
+#ENABLE_FUZZ=true
+ENABLE_ZMQ=false


### PR DESCRIPTION
We currently use a [mock](https://github.com/BitMEXResearch/forkmonitor/blob/master/app/services/bitcoin_client_mock.rb) to simulate the behaviour of the various Bitcoin clients. Unfortunately some of that behaviour is quite difficult to simulate accurately, especially the way it handles forks. This has led to some areas of the code, e.g. the inflation check, to be very hard to test.

Using a real bitcoind nodes, in regtest, should remove the need for a mock. Downside is that it's more complicated to setup and runs slower. The mock should remain useful for testing simpler functionality.  