### PR TITLE
Customize regtest consensus params

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/bitcoin"]
 	path = vendor/bitcoin
-	url = https://github.com/bitcoin/bitcoin.git
+	url = https://github.com/Sjors/bitcoin.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,16 @@ cache:
   directories:
   - /home/travis/.rvm/
   - $HOME/libzmq
+  - $HOME/bin
+  - $HOME/include
+  - $HOME/lib
+  - $HOME/share
 before_install:
-  - cp $TRAVIS_BUILD_DIR/vendor/bitcoin-config.ini $TRAVIS_BUILD_DIR/vendor/bitcoin/test/config.ini
   - $TRAVIS_BUILD_DIR/travis-zmq.sh
-  - cd $TRAVIS_BUILD_DIR/vendor/bitcoin && contrib/devtools/previous_release.sh -b -t .. v0.19.0.1
+  - cp $TRAVIS_BUILD_DIR/vendor/bitcoin-config.ini $TRAVIS_BUILD_DIR/vendor/bitcoin/test/config.ini
+  - sudo apt-get install --no-install-recommends --no-upgrade -y build-essential libtool autotools-dev automake pkg-config bsdmainutils python3 libevent-dev libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb-dev libdb++-dev
+  - # cd $TRAVIS_BUILD_DIR/vendor/bitcoin && contrib/devtools/previous_release.sh -b -t .. v0.19.0.1
+  - $TRAVIS_BUILD_DIR/bitcoind.sh
   - yarn
 before_script:
   - bundle exec rake db:create RAILS_ENV=test

--- a/bitcoind.sh
+++ b/bitcoind.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -o xtrace
+set -e
+cd $TRAVIS_BUILD_DIR/vendor/bitcoin
+if [ ! -f "$HOME/bin/bitcoind" ] || [ `$HOME/bin/bitcoind --version | head -n1 | grep -o '.........$' ` != "4979f59d9" ]; then
+  mkdir -p $HOME
+  ./autogen.sh
+  ./configure --prefix=$HOME --enable-wallet --with-incompatible-bdb --without-gui --disable-tests --disable-bench --without-miniupnpc
+  make
+  make install
+fi

--- a/spec/models/chaintip_spec.rb
+++ b/spec/models/chaintip_spec.rb
@@ -5,7 +5,8 @@ def setup_python_nodes
   @use_python_nodes = true
 
   stub_const("BitcoinClient::Error", BitcoinClientPython::Error)
-  test.setup(num_nodes: 2)
+  stub_const("BitcoinClient::ConnectionError", BitcoinClientPython::ConnectionError)
+  test.setup(num_nodes: 2, extra_args: [[], ["-con_nsubsidyhalvinginterval=10"]])
   @nodeA = create(:node_python)
   @nodeA.client.set_python_node(test.nodes[0])
   @nodeB = create(:node_python)
@@ -206,19 +207,9 @@ RSpec.describe Chaintip, type: :model do
 
   describe "check!" do
     before do
-      @A = create(:node)
-      @A.client.mock_version(170100)
-      @A.client.mock_set_height(560178)
-
-      @B = create(:node)
-      @B.client.mock_version(160300)
-      @B.client.mock_set_height(560178)
+      setup_python_nodes()
     end
-
     describe "one node in IBD" do
-      before do
-        setup_python_nodes()
-      end
       it "should do nothing" do
         @nodeA.ibd = true
         expect(Chaintip.check!(@nodeA)).to eq(nil)
@@ -229,10 +220,6 @@ RSpec.describe Chaintip, type: :model do
     end
 
     describe "only an active chaintip" do
-      before do
-        setup_python_nodes()
-        @A.poll!
-      end
       it "should add a chaintip entry" do
         expect(@nodeA.chaintips.count).to eq(0)
         Chaintip.check!(@nodeA)
@@ -245,7 +232,6 @@ RSpec.describe Chaintip, type: :model do
       let(:user) { create(:user) }
 
       before do
-        setup_python_nodes()
         test.disconnect_nodes(@nodeA.client, 1)
         assert_equal(0, @nodeA.client.getpeerinfo().count)
 
@@ -300,97 +286,84 @@ RSpec.describe Chaintip, type: :model do
       end
     end
 
-    describe "one active and one invalid chaintip, not in our db" do
+    describe "invalid chaintip" do
       before do
-        @B.client.mock_chaintips([
-          {
-            "height" => 560178,
-            "hash" => "00000000000000000016816bd3f4da655a4d1fd326a3313fa086c2e337e854f9",
-            "branchlen" => 0,
-            "status" => "active"
-          }, {
-            "height" => 560179,
-            "hash" => "000000000000000000017b592e9ecd6ce8ab9b5a2f391e21ee2e80b022a7dafc",
-            "branchlen" => 0,
-            "status" => "invalid"
-          }
-        ])
-        @B.poll!
-      end
-      it "should add the active entry" do
-        Chaintip.check!(@B)
-        expect(@B.chaintips.count).to eq(1) # It won't add the invalid entry because it doesn't have the block
-      end
-    end
-
-    describe "one active and one invalid chaintip in our db" do
-      let(:user) { create(:user) }
-
-      before do
-        # Make node A accept the block:
-        @A.client.mock_set_height(560179)
-        @A.poll!
-        @B.client.mock_chaintips([
-          {
-            "height" => 560178,
-            "hash" => "00000000000000000016816bd3f4da655a4d1fd326a3313fa086c2e337e854f9",
-            "branchlen" => 0,
-            "status" => "active"
-          },
-          {
-            "height" => 560179,
-            "hash" => "000000000000000000017b592e9ecd6ce8ab9b5a2f391e21ee2e80b022a7dafc",
-            "branchlen" => 0,
-            "status" => "invalid"
-          }
-        ])
-        @B.poll!
+        # Node B expects the first halving at block 10 instead of block 150.
+        # Generate blocks up to that point:
+        @nodeA.client.generate(7)
+        test.sync_blocks()
+        test.disconnect_nodes(@nodeA.client, 1)
+        assert_equal(0, @nodeA.client.getpeerinfo().count)
+        # Node A will have the longest chain, but its considered invalid by B
+        # because it expects the first halving at height 10.
+        @nodeA.client.generate(3)
+        @nodeB.client.generate(2) # active chaintip
+        test.connect_nodes(@nodeA.client, 1)
+        sleep(1)
       end
 
-      it "should store invalid tip" do
-        disputed_block = @A.block
-        expect(disputed_block.height).to eq(560179)
-        expect(disputed_block.block_hash).to eq("000000000000000000017b592e9ecd6ce8ab9b5a2f391e21ee2e80b022a7dafc")
-        Chaintip.check!(@B)
-        expect(@B.chaintips.where(status: "invalid").count).to eq(1)
+      describe "not in our db" do
+        before do
+          # Don't poll node A, so our DB won't contain the disputed block
+          @nodeB.poll!
+        end
+        it "should add the active entry" do
+          Chaintip.check!(@nodeB)
+          # It won't add the invalid entry because the block is not in our db
+          expect(@nodeB.chaintips.count).to eq(1)
+          expect(@nodeB.chaintips[0].block.height).to eq(11)
+        end
       end
 
-      it "should be nil if the node is unreachable" do
-        stub_const("BitcoinClient::Error", BitcoinClientMock::Error)
-        @B.client.mock_unreachable
-        @B.poll!
-        expect(Chaintip.check!(@B)).to eq(nil)
-      end
+      describe "in our db" do
+        let(:user) { create(:user) }
 
-      it "should store an InvalidBlock entry" do
-        Chaintip.check!(@B)
-        disputed_block = @B.chaintips.last.block
-        expect(InvalidBlock.count).to eq(1)
-        expect(InvalidBlock.first.block).to eq(disputed_block)
-        expect(InvalidBlock.first.node).to eq(@B)
-      end
+        before do
+          @nodeA.poll!
+          @nodeB.poll!
+        end
 
-      it "should send an email to all users" do
-        expect(User).to receive(:all).and_return [user]
-        expect { Chaintip.check!(@B) }.to change { ActionMailer::Base.deliveries.count }.by(1)
-      end
+        it "should store invalid tip" do
+          Chaintip.check!(@nodeB)
+          expect(@nodeB.chaintips.where(status: "invalid").count).to eq(1)
+        end
 
-      it "should send email only once" do
-        expect(User).to receive(:all).and_return [user]
-        expect { Chaintip.check!(@B) }.to change { ActionMailer::Base.deliveries.count }.by(1)
-        expect { Chaintip.check!(@B) }.to change { ActionMailer::Base.deliveries.count }.by(0)
-      end
+        it "should be nil if the node is unreachable" do
+          @nodeB.client.mock_connection_error(true)
+          @nodeB.poll!
+          expect(Chaintip.check!(@nodeB)).to eq(nil)
+        end
 
-      it "node should have invalid blocks" do
-        Chaintip.check!(@B)
-        expect(@B.invalid_blocks.count).to eq(1)
-      end
+        it "should store an InvalidBlock entry" do
+          Chaintip.check!(@nodeB)
+          disputed_block = @nodeA.block
+          expect(InvalidBlock.count).to eq(1)
+          expect(InvalidBlock.first.block).to eq(disputed_block)
+          expect(InvalidBlock.first.node).to eq(@nodeB)
+        end
 
-      it "can not be deleleted" do
-        Chaintip.check!(@B)
-        expect { @B.destroy }.to raise_error ActiveRecord::DeleteRestrictionError
-      end
+        it "should send an email to all users" do
+          expect(User).to receive(:all).and_return [user]
+          expect { Chaintip.check!(@nodeB) }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        end
 
+        it "should send email only once" do
+          expect(User).to receive(:all).and_return [user]
+          expect { Chaintip.check!(@nodeB) }.to change { ActionMailer::Base.deliveries.count }.by(1)
+          expect { Chaintip.check!(@nodeB) }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
+
+        it "node should have invalid blocks" do
+          Chaintip.check!(@nodeB)
+          expect(@nodeB.invalid_blocks.count).to eq(1)
+        end
+
+        it "can not be deleleted" do
+          Chaintip.check!(@nodeB)
+          expect { @nodeB.destroy }.to raise_error ActiveRecord::DeleteRestrictionError
+        end
+
+      end
     end
   end
 end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Node, :type => :model do
 
         it "should store the node version" do
           @node.poll!
-          expect(@node.version).to be 190001
+          expect(@node.version).to be 199900
         end
 
         it "should get IBD status" do

--- a/util.py
+++ b/util.py
@@ -45,7 +45,8 @@ class TestWrapper(BitcoinTestFramework):
               pdbonfailure=False,
               usecli=False,
               perf=False,
-              randomseed=None):
+              randomseed=None,
+              extra_args=None):
 
         self.setup_clean_chain = setup_clean_chain
         self.num_nodes = num_nodes
@@ -53,6 +54,7 @@ class TestWrapper(BitcoinTestFramework):
         self.rpc_timeout = rpc_timeout
         self.supports_cli = supports_cli
         self.bind_to_localhost_only = bind_to_localhost_only
+        self.extra_args = extra_args
 
         self.options = argparse.Namespace
         self.options.nocleanup = nocleanup
@@ -82,6 +84,7 @@ class TestWrapper(BitcoinTestFramework):
             # binary_cli=[os.path.abspath(VENDOR_DIRECTORY + "/v0.19.0.1/bin/bitcoin-cli")] * self.num_nodes,
             binary=[str(Path.home()) + "/bin/bitcoind"] * self.num_nodes,
             binary_cli=[str(Path.home()) + "/bin/bitcoin-cli"] * self.num_nodes,
+            extra_args=self.extra_args,
         )
         self.start_nodes()
 

--- a/util.py
+++ b/util.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import sys
 import importlib.util
+from pathlib import Path
 
 VENDOR_DIRECTORY = os.path.dirname(os.path.abspath(__file__)) + "/vendor"
 
@@ -76,9 +77,11 @@ class TestWrapper(BitcoinTestFramework):
 
     def setup_nodes(self):
         self.add_nodes(self.num_nodes,
-            versions=[190001] * self.num_nodes,
-            binary=[os.path.abspath(VENDOR_DIRECTORY + "/v0.19.0.1/bin/bitcoind")] * self.num_nodes,
-            binary_cli=[os.path.abspath(VENDOR_DIRECTORY + "/v0.19.0.1/bin/bitcoin-cli")] * self.num_nodes,
+            versions=[199900] * self.num_nodes,
+            # binary=[os.path.abspath(VENDOR_DIRECTORY + "/v0.19.0.1/bin/bitcoind")] * self.num_nodes,
+            # binary_cli=[os.path.abspath(VENDOR_DIRECTORY + "/v0.19.0.1/bin/bitcoin-cli")] * self.num_nodes,
+            binary=[str(Path.home()) + "/bin/bitcoind"] * self.num_nodes,
+            binary_cli=[str(Path.home()) + "/bin/bitcoin-cli"] * self.num_nodes,
         )
         self.start_nodes()
 


### PR DESCRIPTION
Switch `vendor/bitcoin` to a rebased version of https://github.com/bitcoin/bitcoin/pull/17032 which adds consensus customization support to regtest. This can be used to trigger consensus failure and test `getchaintips`.