### PR TITLE
Use BDB in test suite

### DIFF
--- a/bitcoind.sh
+++ b/bitcoind.sh
@@ -2,10 +2,10 @@
 set -o xtrace
 set -e
 cd $TRAVIS_BUILD_DIR/vendor/bitcoin
-if [ ! -f "$HOME/bin/bitcoind" ] || [ `$HOME/bin/bitcoind --version | head -n1 | grep -o '.........$' ` != "a8746f976" ]; then
+if [ ! -f "$HOME/bin/bitcoind" ] || [ `$HOME/bin/bitcoind --version | head -n1 | grep -o '............$' ` != "c150ae6b0b46" ]; then
   mkdir -p $HOME
   ./autogen.sh
-  ./configure --prefix=$HOME --enable-wallet --without-bdb --without-gui --disable-tests --disable-bench --without-miniupnpc
+  ./configure --prefix=$HOME --enable-wallet --with-incompatible-bdb --without-sqlite --without-gui --disable-tests --disable-bench --without-miniupnpc
   make
   make install
 fi


### PR DESCRIPTION
Sqlite (descriptor) wallets are extremely slow in the test suite on macOS. This requires a Bitcoin Core patch to support DBD descriptor wallets.