### PR TITLE
Switch test node back to upstream (taproot wallet)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/bitcoin"]
 	path = vendor/bitcoin
-	url = https://github.com/Sjors/bitcoin.git
+	url = https://github.com/bitcoin/bitcoin.git

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fork Monitor [![Build Status](https://travis-ci.org/BitMEXResearch/forkmonitor.svg?branch=master)](https://travis-ci.org/BitMEXResearch/forkmonitor) [![Coverage Status](https://coveralls.io/repos/github/BitMEXResearch/forkmonitor/badge.svg?branch=master)](https://coveralls.io/github/BitMEXResearch/forkmonitor?branch=master)
+# Fork Monitor [![Build Status](https://travis-ci.com/BitMEXResearch/forkmonitor.svg?branch=master)](https://travis-ci.com/BitMEXResearch/forkmonitor) [![Coverage Status](https://coveralls.io/repos/github/BitMEXResearch/forkmonitor/badge.svg?branch=master)](https://coveralls.io/github/BitMEXResearch/forkmonitor?branch=master)
 
 ## Development
 

--- a/bitcoind.sh
+++ b/bitcoind.sh
@@ -2,10 +2,10 @@
 set -o xtrace
 set -e
 cd $TRAVIS_BUILD_DIR/vendor/bitcoin
-if [ ! -f "$HOME/bin/bitcoind" ] || [ `$HOME/bin/bitcoind --version | head -n1 | grep -o '............$' ` != "c150ae6b0b46" ]; then
+if [ ! -f "$HOME/bin/bitcoind" ] || [ `$HOME/bin/bitcoind --version | head -n1 | grep -o '............$' ` != "6a67366fdc3e" ]; then
   mkdir -p $HOME
   ./autogen.sh
-  ./configure --prefix=$HOME --enable-wallet --with-incompatible-bdb --without-sqlite --without-gui --disable-tests --disable-bench --without-miniupnpc
+  ./configure --prefix=$HOME --enable-wallet --without-bdb --without-gui --disable-tests --disable-bench --disable-fuzz-binary --without-miniupnpc --without-natpmp --enable-suppress-external-warnings --disable-external-signer
   make
   make install
 fi

--- a/spec/models/chaintip_spec.rb
+++ b/spec/models/chaintip_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Chaintip, type: :model do
     # Once a release with Taproot support is available, it's best to use that
     # for the second node, so that this test still works when Taproot deployment
     # is burried (at which point vbparams won't work).
-    test.setup(num_nodes: 3, extra_args: [[], ['-vbparams=taproot:1:1'], ['-vbparams=taproot:1:1']])
+    test.setup(num_nodes: 3, extra_args: [['address_type=bech32m'], ['-vbparams=taproot:1:1'], ['-vbparams=taproot:1:1']])
     @node_a = create(:node_python) # Taproot enabled
     @node_a.client.set_python_node(test.nodes[0])
     @node_b = create(:node_python) # Taproot disabled


### PR DESCRIPTION
The chaintip test uses taproot wallet support in order to simulate a chainsplit (using an invalid schnorr signature). Now that taproot wallet support has been merged upstream, we use that.